### PR TITLE
Add push-to-index feature for automatic PR creation

### DIFF
--- a/scripts/push_to_index.py
+++ b/scripts/push_to_index.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""
+Push evaluation results to the OpenHands index repository.
+
+This script reads evaluation results and creates a PR to add them to the
+openhands-index-results repository for display on the leaderboard.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+# Benchmark name mapping from eval benchmark names to index benchmark names
+BENCHMARK_NAME_MAP = {
+    "swe-bench": "swe-bench",
+    "swe_bench": "swe-bench",
+    "swebench": "swe-bench",
+    "swt-bench": "swt-bench",
+    "swt_bench": "swt-bench",
+    "swtbench": "swt-bench",
+    "gaia": "gaia",
+    "commit0": "commit0",
+    "commit-0": "commit0",
+    "multi-swe-bench": "multi-swe-bench",
+    "multi_swe_bench": "multi-swe-bench",
+    "multiswebench": "multi-swe-bench",
+    "swe-bench-multimodal": "swe-bench-multimodal",
+    "swe_bench_multimodal": "swe-bench-multimodal",
+    "swebench-multimodal": "swe-bench-multimodal",
+}
+
+# Valid benchmark names for the index
+VALID_BENCHMARKS = {
+    "swe-bench",
+    "swt-bench",
+    "gaia",
+    "commit0",
+    "multi-swe-bench",
+    "swe-bench-multimodal",
+}
+
+INDEX_REPO_URL = "https://github.com/OpenHands/openhands-index-results.git"
+INDEX_REPO_NAME = "openhands-index-results"
+
+
+def load_json(file_path: Path) -> dict | list | None:
+    """Load JSON file, return None if file doesn't exist or is invalid."""
+    if not file_path.exists():
+        return None
+    try:
+        with open(file_path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return None
+
+
+def load_jsonl(file_path: Path) -> list[dict]:
+    """Load JSONL file, return empty list if file doesn't exist or is invalid."""
+    if not file_path.exists():
+        return []
+    results = []
+    try:
+        with open(file_path) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    results.append(json.loads(line))
+    except (json.JSONDecodeError, IOError):
+        return []
+    return results
+
+
+def calculate_accuracy(report_data: dict) -> float:
+    """Calculate accuracy from output.report.json data."""
+    resolved = report_data.get("resolved_instances", 0)
+    submitted = report_data.get("submitted_instances", 0)
+    if submitted == 0:
+        return 0.0
+    return round((resolved / submitted) * 100, 2)
+
+
+def get_cost_and_duration(cost_report: list[dict]) -> tuple[float, float]:
+    """Extract total_cost and total_duration from cost_report.jsonl."""
+    total_cost = 0.0
+    total_duration = 0.0
+    for entry in cost_report:
+        total_cost += entry.get("total_cost", 0) or 0
+        total_duration += entry.get("total_duration", 0) or 0
+    return round(total_cost, 2), round(total_duration, 2)
+
+
+def normalize_benchmark_name(benchmark: str) -> str:
+    """Normalize benchmark name to the standard index format."""
+    normalized = benchmark.lower().strip()
+    return BENCHMARK_NAME_MAP.get(normalized, normalized)
+
+
+def generate_directory_name(model_name: str, date: datetime | None = None) -> str:
+    """Generate directory name in YYYYMM_model format."""
+    if date is None:
+        date = datetime.now()
+    year_month = date.strftime("%Y%m")
+    # Clean model name for directory
+    clean_model = model_name.replace("/", "-").replace(" ", "-")
+    return f"{year_month}_{clean_model}"
+
+
+def create_metadata(
+    model_name: str,
+    agent_name: str = "OpenHands CodeAct",
+    agent_version: str = "unknown",
+    openness: str = "closed_api_available",
+    tool_usage: str = "standard",
+    directory_name: str = "",
+) -> dict:
+    """Create metadata.json content."""
+    return {
+        "agent_name": agent_name,
+        "agent_version": agent_version,
+        "model": model_name,
+        "openness": openness,
+        "tool_usage": tool_usage,
+        "submission_time": datetime.now().isoformat(),
+        "directory_name": directory_name,
+    }
+
+
+def create_score_entry(
+    benchmark: str,
+    score: float,
+    total_cost: float = 0,
+    total_runtime: float = 0,
+) -> dict:
+    """Create a score entry for scores.json."""
+    normalized_benchmark = normalize_benchmark_name(benchmark)
+    return {
+        "benchmark": normalized_benchmark,
+        "score": score,
+        "metric": "accuracy",
+        "total_cost": total_cost,
+        "total_runtime": total_runtime,
+        "tags": [normalized_benchmark],
+    }
+
+
+def update_scores(existing_scores: list[dict], new_entry: dict) -> list[dict]:
+    """Update scores list, replacing existing entry for same benchmark or adding new."""
+    benchmark = new_entry["benchmark"]
+    updated = False
+    result = []
+    for entry in existing_scores:
+        if entry.get("benchmark") == benchmark:
+            result.append(new_entry)
+            updated = True
+        else:
+            result.append(entry)
+    if not updated:
+        result.append(new_entry)
+    return result
+
+
+def run_command(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> tuple[int, str, str]:
+    """Run a command and return exit code, stdout, stderr."""
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=full_env,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def clone_index_repo(work_dir: Path, token: str) -> Path:
+    """Clone the index repository."""
+    repo_path = work_dir / INDEX_REPO_NAME
+    if repo_path.exists():
+        # Pull latest changes
+        run_command(["git", "fetch", "origin"], cwd=repo_path)
+        run_command(["git", "checkout", "main"], cwd=repo_path)
+        run_command(["git", "pull", "origin", "main"], cwd=repo_path)
+        return repo_path
+
+    # Clone with token
+    auth_url = f"https://x-access-token:{token}@github.com/OpenHands/openhands-index-results.git"
+    exit_code, stdout, stderr = run_command(
+        ["git", "clone", auth_url, INDEX_REPO_NAME],
+        cwd=work_dir,
+    )
+    if exit_code != 0:
+        raise RuntimeError(f"Failed to clone repository: {stderr}")
+    return repo_path
+
+
+def create_branch(repo_path: Path, branch_name: str) -> None:
+    """Create and checkout a new branch."""
+    run_command(["git", "checkout", "-b", branch_name], cwd=repo_path)
+
+
+def commit_and_push(repo_path: Path, branch_name: str, message: str) -> None:
+    """Commit changes and push to remote."""
+    run_command(["git", "add", "."], cwd=repo_path)
+    run_command(["git", "commit", "-m", message], cwd=repo_path)
+    exit_code, stdout, stderr = run_command(
+        ["git", "push", "-u", "origin", branch_name],
+        cwd=repo_path,
+    )
+    if exit_code != 0:
+        raise RuntimeError(f"Failed to push: {stderr}")
+
+
+def create_pull_request(
+    token: str,
+    branch_name: str,
+    title: str,
+    body: str,
+    reviewer: str = "juanmichelini",
+) -> dict:
+    """Create a pull request using GitHub API."""
+    import urllib.request
+    import urllib.error
+
+    api_url = "https://api.github.com/repos/OpenHands/openhands-index-results/pulls"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+        "Content-Type": "application/json",
+    }
+    data = {
+        "title": title,
+        "body": body,
+        "head": branch_name,
+        "base": "main",
+    }
+
+    req = urllib.request.Request(
+        api_url,
+        data=json.dumps(data).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req) as response:
+            pr_data = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8")
+        raise RuntimeError(f"Failed to create PR: {e.code} - {error_body}")
+
+    # Request review
+    pr_number = pr_data["number"]
+    review_url = f"https://api.github.com/repos/OpenHands/openhands-index-results/pulls/{pr_number}/requested_reviewers"
+    review_data = {"reviewers": [reviewer]}
+    review_req = urllib.request.Request(
+        review_url,
+        data=json.dumps(review_data).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(review_req) as response:
+            pass
+    except urllib.error.HTTPError:
+        # Non-fatal: reviewer might not have access
+        print(f"Warning: Could not request review from {reviewer}")
+
+    return pr_data
+
+
+def push_results_to_index(
+    benchmark: str,
+    model_name: str,
+    report_path: Path,
+    cost_report_path: Path,
+    token: str,
+    work_dir: Path,
+    agent_name: str = "OpenHands CodeAct",
+    agent_version: str = "unknown",
+    openness: str = "closed_api_available",
+    tool_usage: str = "standard",
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """
+    Push evaluation results to the index repository.
+
+    Returns a dict with the results of the operation.
+    """
+    # Load report data
+    report_data = load_json(report_path)
+    if report_data is None:
+        report_data = {}
+
+    # Calculate accuracy
+    accuracy = calculate_accuracy(report_data)
+
+    # Load cost report
+    cost_report = load_jsonl(cost_report_path)
+    total_cost, total_duration = get_cost_and_duration(cost_report)
+
+    # Generate directory name
+    dir_name = generate_directory_name(model_name)
+
+    # Normalize benchmark name
+    normalized_benchmark = normalize_benchmark_name(benchmark)
+    if normalized_benchmark not in VALID_BENCHMARKS:
+        raise ValueError(f"Invalid benchmark: {benchmark}. Valid benchmarks: {VALID_BENCHMARKS}")
+
+    result = {
+        "benchmark": normalized_benchmark,
+        "model": model_name,
+        "accuracy": accuracy,
+        "total_cost": total_cost,
+        "total_duration": total_duration,
+        "directory_name": dir_name,
+    }
+
+    if dry_run:
+        print(f"Dry run - would create/update results for {model_name} on {normalized_benchmark}")
+        print(f"  Accuracy: {accuracy}%")
+        print(f"  Total cost: ${total_cost}")
+        print(f"  Total duration: {total_duration}s")
+        return result
+
+    # Clone repository
+    print(f"Cloning index repository to {work_dir}...")
+    repo_path = clone_index_repo(work_dir, token)
+
+    # Create results directory
+    results_dir = repo_path / "results" / dir_name
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load or create metadata
+    metadata_path = results_dir / "metadata.json"
+    if metadata_path.exists():
+        metadata = load_json(metadata_path) or {}
+    else:
+        metadata = create_metadata(
+            model_name=model_name,
+            agent_name=agent_name,
+            agent_version=agent_version,
+            openness=openness,
+            tool_usage=tool_usage,
+            directory_name=dir_name,
+        )
+
+    # Update submission time
+    metadata["submission_time"] = datetime.now().isoformat()
+    metadata["directory_name"] = dir_name
+
+    # Write metadata
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f, indent=2)
+        f.write("\n")
+
+    # Load or create scores
+    scores_path = results_dir / "scores.json"
+    if scores_path.exists():
+        scores = load_json(scores_path) or []
+    else:
+        scores = []
+
+    # Create new score entry
+    new_score = create_score_entry(
+        benchmark=normalized_benchmark,
+        score=accuracy,
+        total_cost=total_cost,
+        total_runtime=total_duration,
+    )
+
+    # Update scores
+    scores = update_scores(scores, new_score)
+
+    # Write scores
+    with open(scores_path, "w") as f:
+        json.dump(scores, f, indent=2)
+        f.write("\n")
+
+    # Create branch
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    branch_name = f"results/{dir_name}-{normalized_benchmark}-{timestamp}"
+    print(f"Creating branch: {branch_name}")
+    create_branch(repo_path, branch_name)
+
+    # Commit and push
+    commit_message = f"Add {normalized_benchmark} results for {model_name}"
+    print(f"Committing: {commit_message}")
+    commit_and_push(repo_path, branch_name, commit_message)
+
+    # Create PR
+    pr_title = f"Add {normalized_benchmark} results for {model_name}"
+    pr_body = f"""## Benchmark Results
+
+This PR adds evaluation results for **{model_name}** on **{normalized_benchmark}**.
+
+### Results Summary
+
+| Metric | Value |
+|--------|-------|
+| Benchmark | {normalized_benchmark} |
+| Model | {model_name} |
+| Accuracy | {accuracy}% |
+| Total Cost | ${total_cost} |
+| Total Duration | {total_duration}s |
+
+### Files Changed
+
+- `results/{dir_name}/metadata.json`
+- `results/{dir_name}/scores.json`
+
+---
+*This PR was automatically generated by the evaluation pipeline.*
+"""
+
+    print("Creating pull request...")
+    pr_data = create_pull_request(
+        token=token,
+        branch_name=branch_name,
+        title=pr_title,
+        body=pr_body,
+        reviewer="juanmichelini",
+    )
+
+    result["pr_url"] = pr_data.get("html_url")
+    result["pr_number"] = pr_data.get("number")
+
+    print(f"Pull request created: {result['pr_url']}")
+    return result
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Push evaluation results to the OpenHands index repository"
+    )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Benchmark name (e.g., swe-bench, gaia, commit0)",
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Model name",
+    )
+    parser.add_argument(
+        "--report-path",
+        type=Path,
+        default=Path("output.report.json"),
+        help="Path to output.report.json",
+    )
+    parser.add_argument(
+        "--cost-report-path",
+        type=Path,
+        default=Path("cost_report.jsonl"),
+        help="Path to cost_report.jsonl",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("PR_TO_INDEX"),
+        help="GitHub token for creating PR (default: PR_TO_INDEX env var)",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=Path("/tmp/index-repo"),
+        help="Working directory for cloning the repository",
+    )
+    parser.add_argument(
+        "--agent-name",
+        default="OpenHands CodeAct",
+        help="Agent name for metadata",
+    )
+    parser.add_argument(
+        "--agent-version",
+        default="unknown",
+        help="Agent version for metadata",
+    )
+    parser.add_argument(
+        "--openness",
+        default="closed_api_available",
+        choices=["open_weights", "closed_api_available", "closed"],
+        help="Model openness classification",
+    )
+    parser.add_argument(
+        "--tool-usage",
+        default="standard",
+        choices=["standard", "custom", "none"],
+        help="Tool usage classification",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be done without making changes",
+    )
+
+    args = parser.parse_args()
+
+    if not args.token and not args.dry_run:
+        print("Error: GitHub token required. Set PR_TO_INDEX environment variable or use --token")
+        sys.exit(1)
+
+    try:
+        result = push_results_to_index(
+            benchmark=args.benchmark,
+            model_name=args.model,
+            report_path=args.report_path,
+            cost_report_path=args.cost_report_path,
+            token=args.token or "",
+            work_dir=args.work_dir,
+            agent_name=args.agent_name,
+            agent_version=args.agent_version,
+            openness=args.openness,
+            tool_usage=args.tool_usage,
+            dry_run=args.dry_run,
+        )
+        print(json.dumps(result, indent=2))
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-eval.sh
+++ b/scripts/run-eval.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Run evaluation and push results to the index repository.
+#
+# This script is designed to be called after an evaluation run completes.
+# It sends a Slack notification and then pushes results to the index repo.
+#
+# Required environment variables:
+#   PR_TO_INDEX - GitHub token for creating PRs to the index repository
+#
+# Optional environment variables:
+#   SLACK_WEBHOOK_URL - Slack webhook URL for notifications
+#   BENCHMARK - Benchmark name (default: swe-bench)
+#   MODEL_NAME - Model name (required)
+#   REPORT_PATH - Path to output.report.json (default: output.report.json)
+#   COST_REPORT_PATH - Path to cost_report.jsonl (default: cost_report.jsonl)
+#   AGENT_NAME - Agent name (default: OpenHands CodeAct)
+#   AGENT_VERSION - Agent version (default: unknown)
+#   OPENNESS - Model openness (default: closed_api_available)
+#   TOOL_USAGE - Tool usage (default: standard)
+#   DRY_RUN - Set to "true" to skip actual PR creation
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Default values
+BENCHMARK="${BENCHMARK:-swe-bench}"
+REPORT_PATH="${REPORT_PATH:-output.report.json}"
+COST_REPORT_PATH="${COST_REPORT_PATH:-cost_report.jsonl}"
+AGENT_NAME="${AGENT_NAME:-OpenHands CodeAct}"
+AGENT_VERSION="${AGENT_VERSION:-unknown}"
+OPENNESS="${OPENNESS:-closed_api_available}"
+TOOL_USAGE="${TOOL_USAGE:-standard}"
+WORK_DIR="${WORK_DIR:-/tmp/index-repo}"
+DRY_RUN="${DRY_RUN:-false}"
+
+# Function to send Slack notification
+send_slack_notification() {
+    local message="$1"
+    if [ -n "$SLACK_WEBHOOK_URL" ]; then
+        curl -s -X POST -H 'Content-type: application/json' \
+            --data "{\"text\": \"$message\"}" \
+            "$SLACK_WEBHOOK_URL" || true
+    fi
+}
+
+# Function to push results to index
+push_to_index() {
+    echo "=== Pushing results to index repository ==="
+
+    if [ -z "$MODEL_NAME" ]; then
+        echo "Error: MODEL_NAME environment variable is required"
+        return 1
+    fi
+
+    if [ -z "$PR_TO_INDEX" ] && [ "$DRY_RUN" != "true" ]; then
+        echo "Error: PR_TO_INDEX environment variable is required"
+        return 1
+    fi
+
+    local dry_run_flag=""
+    if [ "$DRY_RUN" = "true" ]; then
+        dry_run_flag="--dry-run"
+    fi
+
+    python3 "$SCRIPT_DIR/push_to_index.py" \
+        --benchmark "$BENCHMARK" \
+        --model "$MODEL_NAME" \
+        --report-path "$REPORT_PATH" \
+        --cost-report-path "$COST_REPORT_PATH" \
+        --work-dir "$WORK_DIR" \
+        --agent-name "$AGENT_NAME" \
+        --agent-version "$AGENT_VERSION" \
+        --openness "$OPENNESS" \
+        --tool-usage "$TOOL_USAGE" \
+        $dry_run_flag
+
+    return $?
+}
+
+# Main execution
+main() {
+    echo "=== Evaluation Post-Processing ==="
+    echo "Benchmark: $BENCHMARK"
+    echo "Model: $MODEL_NAME"
+    echo "Report path: $REPORT_PATH"
+    echo "Cost report path: $COST_REPORT_PATH"
+
+    # Send Slack notification about evaluation completion
+    send_slack_notification "Evaluation completed for $MODEL_NAME on $BENCHMARK. Pushing results to index..."
+
+    # Push results to index repository
+    if push_to_index; then
+        send_slack_notification "Successfully created PR for $MODEL_NAME on $BENCHMARK results."
+        echo "=== Results pushed successfully ==="
+    else
+        send_slack_notification "Failed to push results for $MODEL_NAME on $BENCHMARK."
+        echo "=== Failed to push results ==="
+        exit 1
+    fi
+}
+
+# Run main if script is executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/test_push_to_index.py
+++ b/tests/test_push_to_index.py
@@ -1,0 +1,432 @@
+"""Tests for the push_to_index script."""
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from push_to_index import (
+    BENCHMARK_NAME_MAP,
+    VALID_BENCHMARKS,
+    calculate_accuracy,
+    create_metadata,
+    create_score_entry,
+    generate_directory_name,
+    get_cost_and_duration,
+    load_json,
+    load_jsonl,
+    normalize_benchmark_name,
+    update_scores,
+)
+
+
+class TestLoadJson:
+    """Tests for load_json function."""
+
+    def test_valid_json(self, tmp_path):
+        """Test loading valid JSON file."""
+        json_file = tmp_path / "test.json"
+        json_file.write_text('{"key": "value"}')
+        result = load_json(json_file)
+        assert result == {"key": "value"}
+
+    def test_nonexistent_file(self, tmp_path):
+        """Test loading nonexistent file returns None."""
+        result = load_json(tmp_path / "nonexistent.json")
+        assert result is None
+
+    def test_invalid_json(self, tmp_path):
+        """Test loading invalid JSON returns None."""
+        json_file = tmp_path / "invalid.json"
+        json_file.write_text("not valid json {{{")
+        result = load_json(json_file)
+        assert result is None
+
+
+class TestLoadJsonl:
+    """Tests for load_jsonl function."""
+
+    def test_valid_jsonl(self, tmp_path):
+        """Test loading valid JSONL file."""
+        jsonl_file = tmp_path / "test.jsonl"
+        jsonl_file.write_text('{"a": 1}\n{"b": 2}\n')
+        result = load_jsonl(jsonl_file)
+        assert result == [{"a": 1}, {"b": 2}]
+
+    def test_nonexistent_file(self, tmp_path):
+        """Test loading nonexistent file returns empty list."""
+        result = load_jsonl(tmp_path / "nonexistent.jsonl")
+        assert result == []
+
+    def test_empty_lines(self, tmp_path):
+        """Test that empty lines are skipped."""
+        jsonl_file = tmp_path / "test.jsonl"
+        jsonl_file.write_text('{"a": 1}\n\n{"b": 2}\n\n')
+        result = load_jsonl(jsonl_file)
+        assert result == [{"a": 1}, {"b": 2}]
+
+    def test_invalid_jsonl(self, tmp_path):
+        """Test loading invalid JSONL returns empty list."""
+        jsonl_file = tmp_path / "invalid.jsonl"
+        jsonl_file.write_text("not valid json\n")
+        result = load_jsonl(jsonl_file)
+        assert result == []
+
+
+class TestCalculateAccuracy:
+    """Tests for calculate_accuracy function."""
+
+    def test_normal_accuracy(self):
+        """Test normal accuracy calculation."""
+        report = {"resolved_instances": 50, "submitted_instances": 100}
+        assert calculate_accuracy(report) == 50.0
+
+    def test_zero_submitted(self):
+        """Test accuracy with zero submitted instances."""
+        report = {"resolved_instances": 10, "submitted_instances": 0}
+        assert calculate_accuracy(report) == 0.0
+
+    def test_missing_fields(self):
+        """Test accuracy with missing fields defaults to 0."""
+        assert calculate_accuracy({}) == 0.0
+        assert calculate_accuracy({"resolved_instances": 10}) == 0.0
+        assert calculate_accuracy({"submitted_instances": 100}) == 0.0
+
+    def test_full_accuracy(self):
+        """Test 100% accuracy."""
+        report = {"resolved_instances": 100, "submitted_instances": 100}
+        assert calculate_accuracy(report) == 100.0
+
+    def test_decimal_accuracy(self):
+        """Test accuracy with decimal result."""
+        report = {"resolved_instances": 33, "submitted_instances": 100}
+        assert calculate_accuracy(report) == 33.0
+
+
+class TestGetCostAndDuration:
+    """Tests for get_cost_and_duration function."""
+
+    def test_single_entry(self):
+        """Test with single cost report entry."""
+        cost_report = [{"total_cost": 100.5, "total_duration": 3600}]
+        cost, duration = get_cost_and_duration(cost_report)
+        assert cost == 100.5
+        assert duration == 3600
+
+    def test_multiple_entries(self):
+        """Test with multiple cost report entries."""
+        cost_report = [
+            {"total_cost": 50.0, "total_duration": 1800},
+            {"total_cost": 75.5, "total_duration": 2400},
+        ]
+        cost, duration = get_cost_and_duration(cost_report)
+        assert cost == 125.5
+        assert duration == 4200
+
+    def test_empty_report(self):
+        """Test with empty cost report."""
+        cost, duration = get_cost_and_duration([])
+        assert cost == 0.0
+        assert duration == 0.0
+
+    def test_missing_fields(self):
+        """Test with missing fields defaults to 0."""
+        cost_report = [{"total_cost": 100}, {"total_duration": 1800}]
+        cost, duration = get_cost_and_duration(cost_report)
+        assert cost == 100.0
+        assert duration == 1800.0
+
+    def test_none_values(self):
+        """Test with None values defaults to 0."""
+        cost_report = [{"total_cost": None, "total_duration": None}]
+        cost, duration = get_cost_and_duration(cost_report)
+        assert cost == 0.0
+        assert duration == 0.0
+
+
+class TestNormalizeBenchmarkName:
+    """Tests for normalize_benchmark_name function."""
+
+    def test_swe_bench_variations(self):
+        """Test SWE-bench name variations."""
+        assert normalize_benchmark_name("swe-bench") == "swe-bench"
+        assert normalize_benchmark_name("swe_bench") == "swe-bench"
+        assert normalize_benchmark_name("swebench") == "swe-bench"
+        assert normalize_benchmark_name("SWE-BENCH") == "swe-bench"
+
+    def test_swt_bench_variations(self):
+        """Test SWT-bench name variations."""
+        assert normalize_benchmark_name("swt-bench") == "swt-bench"
+        assert normalize_benchmark_name("swt_bench") == "swt-bench"
+        assert normalize_benchmark_name("swtbench") == "swt-bench"
+
+    def test_gaia(self):
+        """Test GAIA benchmark."""
+        assert normalize_benchmark_name("gaia") == "gaia"
+        assert normalize_benchmark_name("GAIA") == "gaia"
+
+    def test_commit0(self):
+        """Test commit0 benchmark."""
+        assert normalize_benchmark_name("commit0") == "commit0"
+        assert normalize_benchmark_name("commit-0") == "commit0"
+
+    def test_multi_swe_bench(self):
+        """Test multi-swe-bench variations."""
+        assert normalize_benchmark_name("multi-swe-bench") == "multi-swe-bench"
+        assert normalize_benchmark_name("multi_swe_bench") == "multi-swe-bench"
+        assert normalize_benchmark_name("multiswebench") == "multi-swe-bench"
+
+    def test_swe_bench_multimodal(self):
+        """Test swe-bench-multimodal variations."""
+        assert normalize_benchmark_name("swe-bench-multimodal") == "swe-bench-multimodal"
+        assert normalize_benchmark_name("swe_bench_multimodal") == "swe-bench-multimodal"
+        assert normalize_benchmark_name("swebench-multimodal") == "swe-bench-multimodal"
+
+    def test_unknown_benchmark(self):
+        """Test unknown benchmark returns as-is (lowercase)."""
+        assert normalize_benchmark_name("unknown-benchmark") == "unknown-benchmark"
+
+
+class TestGenerateDirectoryName:
+    """Tests for generate_directory_name function."""
+
+    def test_basic_model_name(self):
+        """Test basic model name."""
+        date = datetime(2025, 11, 15)
+        result = generate_directory_name("gpt-4o", date)
+        assert result == "202511_gpt-4o"
+
+    def test_model_with_slashes(self):
+        """Test model name with slashes."""
+        date = datetime(2025, 12, 1)
+        result = generate_directory_name("org/model-name", date)
+        assert result == "202512_org-model-name"
+
+    def test_model_with_spaces(self):
+        """Test model name with spaces."""
+        date = datetime(2025, 10, 20)
+        result = generate_directory_name("My Model Name", date)
+        assert result == "202510_My-Model-Name"
+
+    def test_default_date(self):
+        """Test that default date uses current date."""
+        result = generate_directory_name("test-model")
+        expected_prefix = datetime.now().strftime("%Y%m")
+        assert result.startswith(expected_prefix)
+        assert result.endswith("_test-model")
+
+
+class TestCreateMetadata:
+    """Tests for create_metadata function."""
+
+    def test_basic_metadata(self):
+        """Test basic metadata creation."""
+        metadata = create_metadata(
+            model_name="gpt-4o",
+            directory_name="202511_gpt-4o",
+        )
+        assert metadata["model"] == "gpt-4o"
+        assert metadata["agent_name"] == "OpenHands CodeAct"
+        assert metadata["agent_version"] == "unknown"
+        assert metadata["openness"] == "closed_api_available"
+        assert metadata["tool_usage"] == "standard"
+        assert metadata["directory_name"] == "202511_gpt-4o"
+        assert "submission_time" in metadata
+
+    def test_custom_metadata(self):
+        """Test metadata with custom values."""
+        metadata = create_metadata(
+            model_name="llama-3",
+            agent_name="Custom Agent",
+            agent_version="1.2.3",
+            openness="open_weights",
+            tool_usage="custom",
+            directory_name="202511_llama-3",
+        )
+        assert metadata["model"] == "llama-3"
+        assert metadata["agent_name"] == "Custom Agent"
+        assert metadata["agent_version"] == "1.2.3"
+        assert metadata["openness"] == "open_weights"
+        assert metadata["tool_usage"] == "custom"
+
+
+class TestCreateScoreEntry:
+    """Tests for create_score_entry function."""
+
+    def test_basic_score_entry(self):
+        """Test basic score entry creation."""
+        entry = create_score_entry(
+            benchmark="swe-bench",
+            score=65.5,
+        )
+        assert entry["benchmark"] == "swe-bench"
+        assert entry["score"] == 65.5
+        assert entry["metric"] == "accuracy"
+        assert entry["total_cost"] == 0
+        assert entry["total_runtime"] == 0
+        assert entry["tags"] == ["swe-bench"]
+
+    def test_score_entry_with_cost(self):
+        """Test score entry with cost and runtime."""
+        entry = create_score_entry(
+            benchmark="gaia",
+            score=80.0,
+            total_cost=150.5,
+            total_runtime=7200,
+        )
+        assert entry["benchmark"] == "gaia"
+        assert entry["score"] == 80.0
+        assert entry["total_cost"] == 150.5
+        assert entry["total_runtime"] == 7200
+
+    def test_score_entry_normalizes_benchmark(self):
+        """Test that benchmark name is normalized."""
+        entry = create_score_entry(
+            benchmark="swe_bench",
+            score=50.0,
+        )
+        assert entry["benchmark"] == "swe-bench"
+        assert entry["tags"] == ["swe-bench"]
+
+
+class TestUpdateScores:
+    """Tests for update_scores function."""
+
+    def test_add_new_score(self):
+        """Test adding a new score to empty list."""
+        existing = []
+        new_entry = {"benchmark": "swe-bench", "score": 65.0}
+        result = update_scores(existing, new_entry)
+        assert len(result) == 1
+        assert result[0] == new_entry
+
+    def test_update_existing_score(self):
+        """Test updating an existing score."""
+        existing = [
+            {"benchmark": "swe-bench", "score": 50.0},
+            {"benchmark": "gaia", "score": 70.0},
+        ]
+        new_entry = {"benchmark": "swe-bench", "score": 65.0}
+        result = update_scores(existing, new_entry)
+        assert len(result) == 2
+        assert result[0]["benchmark"] == "swe-bench"
+        assert result[0]["score"] == 65.0
+        assert result[1]["benchmark"] == "gaia"
+        assert result[1]["score"] == 70.0
+
+    def test_add_different_benchmark(self):
+        """Test adding a score for a different benchmark."""
+        existing = [{"benchmark": "swe-bench", "score": 50.0}]
+        new_entry = {"benchmark": "gaia", "score": 75.0}
+        result = update_scores(existing, new_entry)
+        assert len(result) == 2
+        assert result[0]["benchmark"] == "swe-bench"
+        assert result[1]["benchmark"] == "gaia"
+
+
+class TestValidBenchmarks:
+    """Tests for valid benchmarks constant."""
+
+    def test_all_benchmarks_present(self):
+        """Test that all expected benchmarks are in VALID_BENCHMARKS."""
+        expected = {
+            "swe-bench",
+            "swt-bench",
+            "gaia",
+            "commit0",
+            "multi-swe-bench",
+            "swe-bench-multimodal",
+        }
+        assert VALID_BENCHMARKS == expected
+
+    def test_benchmark_count(self):
+        """Test that we have 6 valid benchmarks."""
+        assert len(VALID_BENCHMARKS) == 6
+
+
+class TestBenchmarkNameMap:
+    """Tests for benchmark name mapping."""
+
+    def test_all_variations_map_to_valid(self):
+        """Test that all mapped names are valid benchmarks."""
+        for source, target in BENCHMARK_NAME_MAP.items():
+            assert target in VALID_BENCHMARKS, f"{source} maps to invalid benchmark {target}"
+
+
+class TestIntegration:
+    """Integration tests for push_to_index functionality."""
+
+    def test_full_workflow_dry_run(self, tmp_path):
+        """Test the full workflow in dry-run mode."""
+        # Create test report file
+        report_path = tmp_path / "output.report.json"
+        report_path.write_text(json.dumps({
+            "resolved_instances": 65,
+            "submitted_instances": 100,
+        }))
+
+        # Create test cost report file
+        cost_report_path = tmp_path / "cost_report.jsonl"
+        cost_report_path.write_text(
+            '{"total_cost": 100.5, "total_duration": 3600}\n'
+            '{"total_cost": 50.0, "total_duration": 1800}\n'
+        )
+
+        # Load and verify data
+        report_data = load_json(report_path)
+        assert report_data is not None
+        accuracy = calculate_accuracy(report_data)
+        assert accuracy == 65.0
+
+        cost_report = load_jsonl(cost_report_path)
+        assert len(cost_report) == 2
+        total_cost, total_duration = get_cost_and_duration(cost_report)
+        assert total_cost == 150.5
+        assert total_duration == 5400
+
+        # Generate directory name
+        dir_name = generate_directory_name("test-model")
+        assert "_test-model" in dir_name
+
+        # Create metadata
+        metadata = create_metadata(
+            model_name="test-model",
+            directory_name=dir_name,
+        )
+        assert metadata["model"] == "test-model"
+
+        # Create score entry
+        score_entry = create_score_entry(
+            benchmark="swe-bench",
+            score=accuracy,
+            total_cost=total_cost,
+            total_runtime=total_duration,
+        )
+        assert score_entry["score"] == 65.0
+        assert score_entry["total_cost"] == 150.5
+        assert score_entry["total_runtime"] == 5400
+
+    def test_missing_report_file(self, tmp_path):
+        """Test handling of missing report file."""
+        report_path = tmp_path / "nonexistent.json"
+        report_data = load_json(report_path)
+        assert report_data is None
+        # Should default to 0 accuracy
+        accuracy = calculate_accuracy(report_data or {})
+        assert accuracy == 0.0
+
+    def test_missing_cost_report_file(self, tmp_path):
+        """Test handling of missing cost report file."""
+        cost_report_path = tmp_path / "nonexistent.jsonl"
+        cost_report = load_jsonl(cost_report_path)
+        assert cost_report == []
+        # Should default to 0 cost and duration
+        total_cost, total_duration = get_cost_and_duration(cost_report)
+        assert total_cost == 0.0
+        assert total_duration == 0.0


### PR DESCRIPTION
## Summary

This PR adds the ability to automatically push evaluation results to the openhands-index-results repository and create a PR for review.

Fixes #12

## Changes

### New Files

1. **`scripts/push_to_index.py`** - Python script that:
   - Reads `output.report.json` to calculate accuracy (`resolved_instances / submitted_instances`)
   - Reads `cost_report.jsonl` to get `total_cost` and `total_duration`
   - Clones the index repository
   - Creates a new branch
   - Creates or updates folder named `YYYYMM_model` (e.g., `202511_Qwen3-Coder-480B-A35B-Instruct-FP8`)
   - Adds or updates `metadata.json` and `scores.json`
   - Creates a PR using the `PR_TO_INDEX` token
   - Assigns the review to @juanmichelini

2. **`scripts/run-eval.sh`** - Shell script wrapper that:
   - Sends Slack notification about evaluation completion
   - Calls `push_to_index.py` to push results
   - Sends Slack notification about PR creation success/failure

3. **`tests/test_push_to_index.py`** - Comprehensive tests for the push_to_index functionality

### Supported Benchmarks

The feature supports all index benchmarks as requested:
- SWE-bench
- SWT-bench
- GAIA
- commit0
- Multi SWE Bench
- SWE-Bench MultiModal

### Usage

```bash
# Set required environment variables
export PR_TO_INDEX="your-github-token"
export MODEL_NAME="gpt-4o"
export BENCHMARK="swe-bench"

# Run the script
./scripts/run-eval.sh
```

Or use the Python script directly:

```bash
python scripts/push_to_index.py \
    --benchmark swe-bench \
    --model gpt-4o \
    --report-path output.report.json \
    --cost-report-path cost_report.jsonl
```

### Dry Run Mode

Both scripts support a dry-run mode for testing:

```bash
DRY_RUN=true ./scripts/run-eval.sh
# or
python scripts/push_to_index.py --dry-run --benchmark swe-bench --model gpt-4o
```

## Testing

All 70 tests pass:
- 16 existing tests for measure_progress.py
- 12 existing tests for validate_schema.py
- 42 new tests for push_to_index.py

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/72d104cb40e54cbd9fe11c89dbd903e2)