### PR TITLE
Support average_runtime metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Contains benchmark scores and performance metrics:
     "score": 45.1,
     "metric": "resolve_rate",
     "total_cost": 32.55,
-    "total_runtime": 3600,
+    "average_runtime": 3600,
     "tags": ["bug_fixing"]
   },
   ...
@@ -72,7 +72,8 @@ Contains benchmark scores and performance metrics:
 - `score`: Primary metric score (percentage or numeric value)
 - `metric`: Type of metric (e.g., "resolve_rate", "success_rate")
 - `total_cost`: Total API cost in USD
-- `total_runtime`: Total runtime in seconds (optional)
+- `average_runtime`: Average runtime in seconds (preferred; optional)
+- `total_runtime`: Legacy runtime in seconds (optional, retained for older results)
 - `tags`: Category tags for grouping (e.g., ["bug_fixing"], ["app_creation"])
 
 ### Legacy Format (Backward Compatible)
@@ -149,7 +150,7 @@ cat > results/20251124_gpt_4o_2024_11_20/scores.json << 'EOF'
     "score": 45.1,
     "metric": "resolve_rate",
     "total_cost": 32.55,
-    "total_runtime": 3600,
+    "average_runtime": 3600,
     "tags": ["bug_fixing"]
   },
   ...

--- a/scripts/measure_progress.py
+++ b/scripts/measure_progress.py
@@ -32,7 +32,8 @@ EXPECTED_BENCHMARKS = [
 EXPECTED_METRICS = [
     "accuracy",            # accuracy (resolve_rate)
     "total_cost",          # monetary cost (#3)
-    "total_runtime",       # wall clock time (#4)
+    # Prefer average_runtime, fall back to total_runtime for legacy results
+    "average_runtime",
 ]
 
 # Expected models from issue #2
@@ -97,6 +98,7 @@ def load_results(results_dir: Path) -> dict:
             benchmark = score_entry.get("benchmark")
             metric = score_entry.get("metric")
             has_total_cost = "total_cost" in score_entry
+            has_average_runtime = "average_runtime" in score_entry
             has_total_runtime = "total_runtime" in score_entry
 
             if benchmark:
@@ -111,10 +113,15 @@ def load_results(results_dir: Path) -> dict:
                 metrics.add("total_cost")
                 if benchmark:
                     coverage[(model_name, benchmark, "total_cost")] = True
-            if has_total_runtime:
-                metrics.add("total_runtime")
+            # Track runtime metrics (prefer average_runtime, include legacy total_runtime)
+            if has_average_runtime:
+                metrics.add("average_runtime")
                 if benchmark:
-                    coverage[(model_name, benchmark, "total_runtime")] = True
+                    coverage[(model_name, benchmark, "average_runtime")] = True
+            if has_total_runtime:
+                metrics.add("average_runtime")
+                if benchmark:
+                    coverage[(model_name, benchmark, "average_runtime")] = True
 
     return {
         "models": models,

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -62,7 +62,11 @@ class ScoreEntry(BaseModel):
     score: float = Field(..., ge=0, le=100, description="Score value (0-100)")
     metric: Metric = Field(..., description="Metric type for the score")
     total_cost: Optional[float] = Field(None, ge=0, description="Total cost in USD")
+    # total_runtime is retained for backward compatibility; prefer average_runtime going forward.
     total_runtime: Optional[float] = Field(None, ge=0, description="Total runtime in seconds")
+    average_runtime: Optional[float] = Field(
+        None, ge=0, description="Average runtime in seconds (preferred)"
+    )
     tags: list[str] = Field(default_factory=list, description="Tags for categorization")
 
     @field_validator("tags")

--- a/tests/test_measure_progress.py
+++ b/tests/test_measure_progress.py
@@ -69,7 +69,7 @@ class TestLoadResults:
         model_dir.mkdir()
 
         metadata = {"model": "test-model", "agent_name": "Test Agent"}
-        scores = [{"benchmark": "swe-bench", "score": 50.0, "metric": "accuracy", "total_cost": 100.0, "total_runtime": 3600}]
+        scores = [{"benchmark": "swe-bench", "score": 50.0, "metric": "accuracy", "total_cost": 100.0, "average_runtime": 3600}]
 
         (model_dir / "metadata.json").write_text(json.dumps(metadata))
         (model_dir / "scores.json").write_text(json.dumps(scores))
@@ -79,10 +79,10 @@ class TestLoadResults:
         assert "swe-bench" in results["benchmarks"]
         assert "accuracy" in results["metrics"]
         assert "total_cost" in results["metrics"]
-        assert "total_runtime" in results["metrics"]
+        assert "average_runtime" in results["metrics"]
         assert results["coverage"][("test-model", "swe-bench", "accuracy")] is True
         assert results["coverage"][("test-model", "swe-bench", "total_cost")] is True
-        assert results["coverage"][("test-model", "swe-bench", "total_runtime")] is True
+        assert results["coverage"][("test-model", "swe-bench", "average_runtime")] is True
 
     def test_skips_invalid_json(self, tmp_path):
         """Test that invalid JSON files are skipped."""
@@ -108,7 +108,7 @@ class TestExpectedDimensions:
         assert len(EXPECTED_METRICS) == 3
         assert "accuracy" in EXPECTED_METRICS
         assert "total_cost" in EXPECTED_METRICS
-        assert "total_runtime" in EXPECTED_METRICS
+        assert "average_runtime" in EXPECTED_METRICS
 
     def test_expected_models_count(self):
         """Test that we have 10 expected models."""
@@ -144,11 +144,11 @@ class TestCalculateProgress:
         results = {
             "models": {"gpt-5"},
             "benchmarks": {"swe-bench"},
-            "metrics": {"accuracy", "total_cost", "total_runtime"},
+            "metrics": {"accuracy", "total_cost", "average_runtime"},
             "coverage": {
                 ("gpt-5", "swe-bench", "accuracy"): True,
                 ("gpt-5", "swe-bench", "total_cost"): True,
-                ("gpt-5", "swe-bench", "total_runtime"): True,
+                ("gpt-5", "swe-bench", "average_runtime"): True,
             },
         }
         progress = calculate_progress(results)
@@ -186,7 +186,7 @@ class TestCalculateProgress:
         results = {
             "models": {"gpt-5"},
             "benchmarks": {"swe-bench"},
-            "metrics": {"accuracy"},  # Only accuracy, missing total_cost and total_runtime
+            "metrics": {"accuracy"},  # Only accuracy, missing total_cost and runtime
             "coverage": {
                 ("gpt-5", "swe-bench", "accuracy"): True,
             },
@@ -232,4 +232,4 @@ class TestIntegration:
         # Verify actual metrics are found
         assert "accuracy" in results["metrics"]
         assert "total_cost" in results["metrics"]
-        assert "total_runtime" in results["metrics"]
+        assert "average_runtime" in results["metrics"]

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -84,7 +84,7 @@ class TestScoreEntrySchema:
             "score": 68.8,
             "metric": "accuracy",
             "total_cost": 206.00,
-            "total_runtime": 3600,
+            "average_runtime": 3600,
             "tags": ["swe-bench"]
         }]
         scores_file = tmp_path / "scores.json"
@@ -185,7 +185,7 @@ class TestValidateResultsDirectory:
             "score": 68.8,
             "metric": "accuracy",
             "total_cost": 206.00,
-            "total_runtime": 0,
+            "average_runtime": 0,
             "tags": ["swe-bench"]
         }]
 


### PR DESCRIPTION
## Summary
- add  to score schema while keeping legacy 
- update progress tooling to count runtime coverage via  (and map legacy  into it)
- adjust docs and tests to prefer 

## Notes
- legacy scores with  still validate and count towards runtime coverage
- new submissions should populate 
