### PR TITLE
Add commit0 results for anthropic/claude-opus-4-5-20251101

### DIFF
--- a/results/202601_anthropic-claude-opus-4-5-20251101/metadata.json
+++ b/results/202601_anthropic-claude-opus-4-5-20251101/metadata.json
@@ -1,0 +1,9 @@
+{
+  "agent_name": "OpenHands CodeAct",
+  "agent_version": "ccf4b2589a3b18009fb66014df216485f20597b0",
+  "model": "anthropic/claude-opus-4-5-20251101",
+  "openness": "closed_api_available",
+  "tool_usage": "standard",
+  "submission_time": "2026-01-09T04:26:47.638613+00:00",
+  "directory_name": "202601_anthropic-claude-opus-4-5-20251101"
+}

--- a/results/202601_anthropic-claude-opus-4-5-20251101/scores.json
+++ b/results/202601_anthropic-claude-opus-4-5-20251101/scores.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "commit0",
+    "score": 50.0,
+    "metric": "accuracy",
+    "total_cost": 0.0,
+    "total_runtime": 0.0,
+    "tags": [
+      "commit0"
+    ]
+  }
+]


### PR DESCRIPTION
## Evaluation Results

**Model:** `anthropic/claude-opus-4-5-20251101`
**Benchmark:** `commit0`
**Agent Version:** `ccf4b2589a3b18009fb66014df216485f20597b0`

### Results
- **Accuracy:** 50.0%
- **Total Cost:** $0.00
- **Average Runtime:** 0s

---
*This PR was manually created from evaluation pipeline results.*
