### PR TITLE
Add gaia results for minimax/minimax-m2

### DIFF
--- a/results/202601_minimax-minimax-m2/metadata.json
+++ b/results/202601_minimax-minimax-m2/metadata.json
@@ -1,0 +1,9 @@
+{
+  "agent_name": "OpenHands CodeAct",
+  "agent_version": "9b75953bcc4d27c5f5f84469c9d32e1c1cddac2e",
+  "model": "minimax/minimax-m2",
+  "openness": "closed_api_available",
+  "tool_usage": "standard",
+  "submission_time": "2026-01-09T04:26:56.150936+00:00",
+  "directory_name": "202601_minimax-minimax-m2"
+}

--- a/results/202601_minimax-minimax-m2/scores.json
+++ b/results/202601_minimax-minimax-m2/scores.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "gaia",
+    "score": 0.0,
+    "metric": "accuracy",
+    "total_cost": 0.0,
+    "total_runtime": 0.0,
+    "tags": [
+      "gaia"
+    ]
+  }
+]


### PR DESCRIPTION
## Evaluation Results

**Model:** `minimax/minimax-m2`
**Benchmark:** `gaia`
**Agent Version:** `9b75953bcc4d27c5f5f84469c9d32e1c1cddac2e`

### Results
- **Accuracy:** 0.0%
- **Total Cost:** $0.00
- **Average Runtime:** 0s

---
*This PR was manually created from evaluation pipeline results.*
