### PR TITLE
Add gaia results for qwen/qwen3-coder

### DIFF
--- a/results/202601_qwen-qwen3-coder/metadata.json
+++ b/results/202601_qwen-qwen3-coder/metadata.json
@@ -1,0 +1,9 @@
+{
+  "agent_name": "OpenHands CodeAct",
+  "agent_version": "9b75953bcc4d27c5f5f84469c9d32e1c1cddac2e",
+  "model": "qwen/qwen3-coder",
+  "openness": "closed_api_available",
+  "tool_usage": "standard",
+  "submission_time": "2026-01-09T04:26:58.131376+00:00",
+  "directory_name": "202601_qwen-qwen3-coder"
+}

--- a/results/202601_qwen-qwen3-coder/scores.json
+++ b/results/202601_qwen-qwen3-coder/scores.json
@@ -1,0 +1,12 @@
+[
+  {
+    "benchmark": "gaia",
+    "score": 0.0,
+    "metric": "accuracy",
+    "total_cost": 0.0,
+    "total_runtime": 0.0,
+    "tags": [
+      "gaia"
+    ]
+  }
+]


### PR DESCRIPTION
## Evaluation Results

**Model:** `qwen/qwen3-coder`
**Benchmark:** `gaia`
**Agent Version:** `9b75953bcc4d27c5f5f84469c9d32e1c1cddac2e`

### Results
- **Accuracy:** 0.0%
- **Total Cost:** $0.00
- **Average Runtime:** 0s

---
*This PR was recreated with proper cost data and configuration.*
