### PR TITLE
refactor: Rename cost_per_problem to cost_per_instance

### DIFF
--- a/results/202510_gpt-5/scores.json
+++ b/results/202510_gpt-5/scores.json
@@ -7,6 +7,6 @@
     "tags": [
       "swe-bench"
     ],
-    "cost_per_problem": 0.412
+    "cost_per_instance": 0.412
   }
 ]

--- a/results/202511_claude-4.5-opus/scores.json
+++ b/results/202511_claude-4.5-opus/scores.json
@@ -7,6 +7,6 @@
     "tags": [
       "swe-bench"
     ],
-    "cost_per_problem": 1.9591
+    "cost_per_instance": 1.9591
   }
 ]

--- a/results/202511_claude-4.5-sonnet/scores.json
+++ b/results/202511_claude-4.5-sonnet/scores.json
@@ -7,6 +7,6 @@
     "tags": [
       "swe-bench"
     ],
-    "cost_per_problem": 1.3763
+    "cost_per_instance": 1.3763
   }
 ]

--- a/results/202511_gemini-3-pro/scores.json
+++ b/results/202511_gemini-3-pro/scores.json
@@ -7,6 +7,6 @@
     "tags": [
       "swe-bench"
     ],
-    "cost_per_problem": 2.3154
+    "cost_per_instance": 2.3154
   }
 ]

--- a/results/202511_qwen-3-coder/scores.json
+++ b/results/202511_qwen-3-coder/scores.json
@@ -7,6 +7,6 @@
     "tags": [
       "swe-bench"
     ],
-    "cost_per_problem": 0.434
+    "cost_per_instance": 0.434
   }
 ]

--- a/results/202601_claude-4.5-opus/scores.json
+++ b/results/202601_claude-4.5-opus/scores.json
@@ -8,7 +8,7 @@
     "tags": [
       "swe-bench-multimodal"
     ],
-    "cost_per_problem": 2.2653
+    "cost_per_instance": 2.2653
   },
   {
     "benchmark": "commit0",
@@ -19,7 +19,7 @@
     "tags": [
       "commit0"
     ],
-    "cost_per_problem": 1.077
+    "cost_per_instance": 1.077
   },
   {
     "benchmark": "gaia",
@@ -30,6 +30,6 @@
     "tags": [
       "gaia"
     ],
-    "cost_per_problem": 0.5473
+    "cost_per_instance": 0.5473
   }
 ]

--- a/results/202601_claude-4.5-sonnet/scores.json
+++ b/results/202601_claude-4.5-sonnet/scores.json
@@ -8,7 +8,7 @@
     "tags": [
       "commit0"
     ],
-    "cost_per_problem": 0.7844
+    "cost_per_instance": 0.7844
   },
   {
     "benchmark": "gaia",
@@ -19,6 +19,6 @@
     "tags": [
       "gaia"
     ],
-    "cost_per_problem": 0.3804
+    "cost_per_instance": 0.3804
   }
 ]

--- a/results/202601_deepseek-v3.2-reasoner/scores.json
+++ b/results/202601_deepseek-v3.2-reasoner/scores.json
@@ -8,7 +8,7 @@
     "tags": [
       "gaia"
     ],
-    "cost_per_problem": 0.0611
+    "cost_per_instance": 0.0611
   },
   {
     "benchmark": "commit0",
@@ -19,6 +19,6 @@
     "tags": [
       "commit0"
     ],
-    "cost_per_problem": 0.0344
+    "cost_per_instance": 0.0344
   }
 ]

--- a/results/202601_gemini-3-flash/scores.json
+++ b/results/202601_gemini-3-flash/scores.json
@@ -8,7 +8,7 @@
     "tags": [
       "commit0"
     ],
-    "cost_per_problem": 0.2435
+    "cost_per_instance": 0.2435
   },
   {
     "benchmark": "gaia",
@@ -19,6 +19,6 @@
     "tags": [
       "gaia"
     ],
-    "cost_per_problem": 0.3754
+    "cost_per_instance": 0.3754
   }
 ]

--- a/results/202601_gemini-3-pro/scores.json
+++ b/results/202601_gemini-3-pro/scores.json
@@ -8,7 +8,7 @@
     "tags": [
       "swe-bench"
     ],
-    "cost_per_problem": 0.9513
+    "cost_per_instance": 0.9513
   },
   {
     "benchmark": "commit0",
@@ -19,6 +19,6 @@
     "tags": [
       "commit0"
     ],
-    "cost_per_problem": 0.795
+    "cost_per_instance": 0.795
   }
 ]

--- a/results/202601_gpt-5.2-high-reasoning/scores.json
+++ b/results/202601_gpt-5.2-high-reasoning/scores.json
@@ -8,6 +8,6 @@
     "tags": [
       "commit0"
     ],
-    "cost_per_problem": 0.2541
+    "cost_per_instance": 0.2541
   }
 ]

--- a/results/202601_gpt-5.2/scores.json
+++ b/results/202601_gpt-5.2/scores.json
@@ -8,7 +8,7 @@
     "tags": [
       "swe-bench-multimodal"
     ],
-    "cost_per_problem": 1.5514
+    "cost_per_instance": 1.5514
   },
   {
     "benchmark": "swe-bench",
@@ -19,7 +19,7 @@
     "tags": [
       "swe-bench"
     ],
-    "cost_per_problem": 0.8334
+    "cost_per_instance": 0.8334
   },
   {
     "benchmark": "gaia",
@@ -30,7 +30,7 @@
     "tags": [
       "gaia"
     ],
-    "cost_per_problem": 0.4805
+    "cost_per_instance": 0.4805
   },
   {
     "benchmark": "commit0",
@@ -40,6 +40,6 @@
     "tags": [
       "commit0"
     ],
-    "cost_per_problem": 0.2098
+    "cost_per_instance": 0.2098
   }
 ]

--- a/results/202601_kimi-k2-thinking/scores.json
+++ b/results/202601_kimi-k2-thinking/scores.json
@@ -8,7 +8,7 @@
     "tags": [
       "swe-bench"
     ],
-    "cost_per_problem": 1.2417
+    "cost_per_instance": 1.2417
   },
   {
     "benchmark": "commit0",
@@ -18,6 +18,6 @@
     "tags": [
       "commit0"
     ],
-    "cost_per_problem": 2.0074
+    "cost_per_instance": 2.0074
   }
 ]

--- a/results/202601_qwen-3-coder/scores.json
+++ b/results/202601_qwen-3-coder/scores.json
@@ -8,6 +8,6 @@
     "tags": [
       "swe-bench"
     ],
-    "cost_per_problem": 1.2244
+    "cost_per_instance": 1.2244
   }
 ]

--- a/scripts/measure_progress.py
+++ b/scripts/measure_progress.py
@@ -31,7 +31,7 @@ EXPECTED_BENCHMARKS = [
 # Expected metrics from issue #2
 EXPECTED_METRICS = [
     "accuracy",            # accuracy (resolve_rate)
-    "cost_per_problem",    # monetary cost per problem (#3)
+    "cost_per_instance",    # monetary cost per problem (#3)
     "average_runtime",     # wall clock time (#4)
 ]
 
@@ -96,7 +96,7 @@ def load_results(results_dir: Path) -> dict:
         for score_entry in scores:
             benchmark = score_entry.get("benchmark")
             metric = score_entry.get("metric")
-            has_cost_per_problem = "cost_per_problem" in score_entry
+            has_cost_per_instance = "cost_per_instance" in score_entry
             has_average_runtime = "average_runtime" in score_entry
 
             if benchmark:
@@ -106,11 +106,11 @@ def load_results(results_dir: Path) -> dict:
                 if benchmark:
                     coverage[(model_name, benchmark, metric)] = True
 
-            # Track cost_per_problem and average_runtime as separate metrics
-            if has_cost_per_problem:
-                metrics.add("cost_per_problem")
+            # Track cost_per_instance and average_runtime as separate metrics
+            if has_cost_per_instance:
+                metrics.add("cost_per_instance")
                 if benchmark:
-                    coverage[(model_name, benchmark, "cost_per_problem")] = True
+                    coverage[(model_name, benchmark, "cost_per_instance")] = True
             if has_average_runtime:
                 metrics.add("average_runtime")
                 if benchmark:

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -122,7 +122,7 @@ class ScoreEntry(BaseModel):
     benchmark: Benchmark = Field(..., description="Benchmark name")
     score: float = Field(..., ge=0, le=100, description="Score value (0-100)")
     metric: Metric = Field(..., description="Metric type for the score")
-    cost_per_problem: Optional[float] = Field(None, ge=0, description="Average cost per problem in USD")
+    cost_per_instance: Optional[float] = Field(None, ge=0, description="Average cost per problem in USD")
     average_runtime: Optional[float] = Field(None, ge=0, description="Average runtime per instance in seconds")
     tags: list[str] = Field(default_factory=list, description="Tags for categorization")
 

--- a/tests/test_measure_progress.py
+++ b/tests/test_measure_progress.py
@@ -67,7 +67,7 @@ class TestLoadResults:
         model_dir.mkdir()
 
         metadata = {"model": "test-model", "agent_name": "Test Agent"}
-        scores = [{"benchmark": "swe-bench", "score": 50.0, "metric": "accuracy", "cost_per_problem": 0.2, "average_runtime": 3600}]
+        scores = [{"benchmark": "swe-bench", "score": 50.0, "metric": "accuracy", "cost_per_instance": 0.2, "average_runtime": 3600}]
 
         (model_dir / "metadata.json").write_text(json.dumps(metadata))
         (model_dir / "scores.json").write_text(json.dumps(scores))
@@ -76,10 +76,10 @@ class TestLoadResults:
         assert "test-model" in results["models"]
         assert "swe-bench" in results["benchmarks"]
         assert "accuracy" in results["metrics"]
-        assert "cost_per_problem" in results["metrics"]
+        assert "cost_per_instance" in results["metrics"]
         assert "average_runtime" in results["metrics"]
         assert results["coverage"][("test-model", "swe-bench", "accuracy")] is True
-        assert results["coverage"][("test-model", "swe-bench", "cost_per_problem")] is True
+        assert results["coverage"][("test-model", "swe-bench", "cost_per_instance")] is True
         assert results["coverage"][("test-model", "swe-bench", "average_runtime")] is True
 
     def test_skips_invalid_json(self, tmp_path):
@@ -105,7 +105,7 @@ class TestExpectedDimensions:
         """Test that we have 3 expected metrics."""
         assert len(EXPECTED_METRICS) == 3
         assert "accuracy" in EXPECTED_METRICS
-        assert "cost_per_problem" in EXPECTED_METRICS
+        assert "cost_per_instance" in EXPECTED_METRICS
         assert "average_runtime" in EXPECTED_METRICS
 
     def test_expected_models_count(self):
@@ -143,10 +143,10 @@ class TestCalculateProgress:
         results = {
             "models": {"gpt-5.2"},
             "benchmarks": {"swe-bench"},
-            "metrics": {"accuracy", "cost_per_problem", "average_runtime"},
+            "metrics": {"accuracy", "cost_per_instance", "average_runtime"},
             "coverage": {
                 ("gpt-5.2", "swe-bench", "accuracy"): True,
-                ("gpt-5.2", "swe-bench", "cost_per_problem"): True,
+                ("gpt-5.2", "swe-bench", "cost_per_instance"): True,
                 ("gpt-5.2", "swe-bench", "average_runtime"): True,
             },
         }
@@ -235,5 +235,5 @@ class TestIntegration:
 
         # Verify actual metrics are found
         assert "accuracy" in results["metrics"]
-        assert "cost_per_problem" in results["metrics"]
+        assert "cost_per_instance" in results["metrics"]
         assert "average_runtime" in results["metrics"]

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -173,7 +173,7 @@ class TestScoreEntrySchema:
             "benchmark": "swe-bench",
             "score": 68.8,
             "metric": "accuracy",
-            "cost_per_problem": 0.412,  # Cost per problem in USD
+            "cost_per_instance": 0.412,  # Cost per problem in USD
             "average_runtime": 3600,
             "tags": ["swe-bench"]
         }]
@@ -215,12 +215,12 @@ class TestScoreEntrySchema:
         assert "score" in msg.lower()
 
     def test_negative_cost(self, tmp_path):
-        """Test score entry with negative cost_per_problem fails validation."""
+        """Test score entry with negative cost_per_instance fails validation."""
         scores = [{
             "benchmark": "swe-bench",
             "score": 68.8,
             "metric": "accuracy",
-            "cost_per_problem": -0.5,  # Invalid - negative
+            "cost_per_instance": -0.5,  # Invalid - negative
             "tags": []
         }]
         scores_file = tmp_path / "scores.json"
@@ -228,7 +228,7 @@ class TestScoreEntrySchema:
 
         valid, msg = validate_scores(scores_file)
         assert valid is False
-        assert "cost_per_problem" in msg.lower()
+        assert "cost_per_instance" in msg.lower()
 
     def test_optional_fields(self, tmp_path):
         """Test that optional fields can be omitted."""
@@ -274,7 +274,7 @@ class TestValidateResultsDirectory:
             "benchmark": "swe-bench",
             "score": 68.8,
             "metric": "accuracy",
-            "cost_per_problem": 0.412,  # Cost per problem in USD
+            "cost_per_instance": 0.412,  # Cost per problem in USD
             "average_runtime": 0,
             "tags": ["swe-bench"]
         }]


### PR DESCRIPTION
## Summary

Rename `cost_per_problem` to `cost_per_instance` for terminology consistency.

## Rationale

The term "instance" is used consistently throughout the ecosystem:
- SWE-Bench documentation refers to "instances"
- Evaluation pipeline PR descriptions use "Total instances", "Submitted instances", etc.
- HuggingFace datasets use "instances" terminology

This rename aligns the schema with existing conventions.

## Changes

- Rename `cost_per_problem` → `cost_per_instance` in:
  - `scripts/validate_schema.py` (ScoreEntry model)
  - `scripts/measure_progress.py` (metric tracking)
  - All `results/*/scores.json` files
  - All test files

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)