### PR TITLE
Add swe-bench-multimodal results for gpt-5.2-high-reasoning

### DIFF
--- a/results/v1.8.2_gpt-5.2-high-reasoning/scores.json
+++ b/results/v1.8.2_gpt-5.2-high-reasoning/scores.json
@@ -9,5 +9,16 @@
       "commit0"
     ],
     "cost_per_instance": 0.2541
+  },
+  {
+    "benchmark": "swe-bench-multimodal",
+    "score": 25.7,
+    "metric": "accuracy",
+    "total_cost": 113.94,
+    "average_runtime": 1123,
+    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21047727077-gpt-5-2-hi_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-16-03-36.tar.gz",
+    "tags": [
+      "swe-bench-multimodal"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
Adds swe-bench-multimodal results for gpt-5.2-high-reasoning.

- **Score**: 25.7% accuracy
- **Archive**: eval-21047727077

Supersedes #187 (fixes directory naming and merge conflicts)

Closes #56