### PR TITLE
Add commit0 results for qwen-3-coder

### DIFF
--- a/results/v1.8.2_qwen-3-coder/scores.json
+++ b/results/v1.8.2_qwen-3-coder/scores.json
@@ -9,5 +9,16 @@
       "swe-bench"
     ],
     "cost_per_instance": 1.2244
+  },
+  {
+    "benchmark": "commit0",
+    "score": 0.0,
+    "metric": "accuracy",
+    "total_cost": 28.66,
+    "average_runtime": 1056,
+    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20981821017-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-14-06-17.tar.gz",
+    "tags": [
+      "commit0"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
Adds commit0 results for qwen-3-coder to the existing results directory.

- **Score**: 0.0% accuracy
- **Archive**: eval-20981821017

Supersedes #155 (fixes directory naming to use existing `v1.8.2_qwen-3-coder` instead of creating a new directory with raw model path)

Closes #90