### PR TITLE
Revert "Add swt-bench results for claude-4.5-opus"

### DIFF
--- a/results/v1.8.3_claude-4.5-opus/metadata.json
+++ b/results/v1.8.3_claude-4.5-opus/metadata.json
@@ -4,6 +4,6 @@
   "model": "claude-4.5-opus",
   "openness": "closed_api_available",
   "tool_usage": "standard",
-  "submission_time": "2026-01-20T14:14:04.086784+00:00",
+  "submission_time": "2026-01-17T19:02:54.502918+00:00",
   "directory_name": "v1.8.3_claude-4.5-opus"
 }

--- a/results/v1.8.3_claude-4.5-opus/scores.json
+++ b/results/v1.8.3_claude-4.5-opus/scores.json
@@ -41,16 +41,5 @@
       "swe-bench"
     ],
     "cost_per_instance": 1.9591
-  },
-  {
-    "benchmark": "swt-bench",
-    "score": 68.8,
-    "metric": "accuracy",
-    "cost_per_instance": 0.98,
-    "average_runtime": 488.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21146174206-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-19-23-25.tar.gz",
-    "tags": [
-      "swt-bench"
-    ]
   }
 ]


### PR DESCRIPTION
Reverts OpenHands/openhands-index-results#277

@neubig reverting PR because it says opus but the results are for sonnet. 
The correct PR with sonnet model has been pushed here https://github.com/OpenHands/openhands-index-results/pull/281