### PR TITLE
Add SWE-bench Multimodal results with 0 values for deepseek-v3.2-reasoner and minimax-m2

### DIFF
--- a/results/v1.8.2_deepseek-v3.2-reasoner/scores.json
+++ b/results/v1.8.2_deepseek-v3.2-reasoner/scores.json
@@ -20,5 +20,15 @@
     "tags": [
       "commit0"
     ]
+  },
+  {
+    "benchmark": "swe-bench-multimodal",
+    "score": 0,
+    "metric": "accuracy",
+    "cost_per_instance": 0,
+    "average_runtime": 0,
+    "tags": [
+      "swe-bench-multimodal"
+    ]
   }
 ]

--- a/results/v1.8.3_minimax-m2/scores.json
+++ b/results/v1.8.3_minimax-m2/scores.json
@@ -20,5 +20,15 @@
     "tags": [
       "commit0"
     ]
+  },
+  {
+    "benchmark": "swe-bench-multimodal",
+    "score": 0,
+    "metric": "accuracy",
+    "cost_per_instance": 0,
+    "average_runtime": 0,
+    "tags": [
+      "swe-bench-multimodal"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Add swe-bench-multimodal benchmark entries with 0 values for:
- v1.8.2_deepseek-v3.2-reasoner
- v1.8.3_minimax-m2

## Details

Multiple runs of SWE-bench Multimodal with these models ended in 0 resolved. For completeness, adding them with:
- accuracy: 0
- cost_per_instance: 0
- average_runtime: 0

As requested, the `full_archive` field is not included for these entries.

## Related Issues

Fixes #286

## Testing

- Schema validation passes
- All existing tests pass

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0a9658acd40748089fd82964876a4af7)