### PR TITLE
Update evaluation result URLs to use new CDN format

### DIFF
--- a/results/v1.8.2_deepseek-v3.2-reasoner/scores.json
+++ b/results/v1.8.2_deepseek-v3.2-reasoner/scores.json
@@ -5,7 +5,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.06,
     "average_runtime": 427.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21070491317-deepseek-v_litellm_proxy-deepseek-deepseek-reasoner_26-01-16-16-39.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21070491317-deepseek-v_litellm_proxy-deepseek-deepseek-reasoner_26-01-16-16-39.tar.gz",
     "tags": [
       "gaia"
     ]
@@ -16,7 +16,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.12,
     "average_runtime": 1411.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20981821017-deepseek-v_litellm_proxy-deepseek-deepseek-reasoner_26-01-14-07-15.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-20981821017-deepseek-v_litellm_proxy-deepseek-deepseek-reasoner_26-01-14-07-15.tar.gz",
     "tags": [
       "commit0"
     ]

--- a/results/v1.8.3_claude-4.5-opus/scores.json
+++ b/results/v1.8.3_claude-4.5-opus/scores.json
@@ -5,7 +5,7 @@
     "metric": "accuracy",
     "cost_per_instance": 2.55,
     "average_runtime": 694.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21039823837-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-15-21-09.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21039823837-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-15-21-09.tar.gz",
     "tags": [
       "swe-bench-multimodal"
     ]
@@ -16,7 +16,7 @@
     "metric": "accuracy",
     "cost_per_instance": 3.64,
     "average_runtime": 620.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20798907628-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-07-23-57.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-20798907628-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-07-23-57.tar.gz",
     "tags": [
       "commit0"
     ]
@@ -27,7 +27,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.55,
     "average_runtime": 97.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20805719842-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-08-06-24.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-20805719842-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-08-06-24.tar.gz",
     "tags": [
       "gaia"
     ]
@@ -48,7 +48,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.38,
     "average_runtime": 268.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21173239168-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-20-19-27.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21173239168-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-20-19-27.tar.gz",
     "tags": [
       "swt-bench"
     ]

--- a/results/v1.8.3_claude-4.5-sonnet/scores.json
+++ b/results/v1.8.3_claude-4.5-sonnet/scores.json
@@ -5,7 +5,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.19,
     "average_runtime": 534.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21104232299-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-18-07-25.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21104232299-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-18-07-25.tar.gz",
     "tags": [
       "swe-bench"
     ]
@@ -16,7 +16,7 @@
     "metric": "accuracy",
     "cost_per_instance": 2.65,
     "average_runtime": 744.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20864634656-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-09-21-31.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-20864634656-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-09-21-31.tar.gz",
     "tags": [
       "commit0"
     ]
@@ -27,7 +27,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.38,
     "average_runtime": 126.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20782040922-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-07-15-35.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-20782040922-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-07-15-35.tar.gz",
     "tags": [
       "gaia"
     ]
@@ -38,7 +38,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.77,
     "average_runtime": 893.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21115061696-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-18-19-23.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21115061696-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-18-19-23.tar.gz",
     "tags": [
       "swe-bench-multimodal"
     ]
@@ -49,7 +49,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.98,
     "average_runtime": 488.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21146174206-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-19-23-25.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21146174206-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-19-23-25.tar.gz",
     "tags": [
       "swt-bench"
     ]

--- a/results/v1.8.3_gemini-3-flash/scores.json
+++ b/results/v1.8.3_gemini-3-flash/scores.json
@@ -5,7 +5,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.77,
     "average_runtime": 638.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21050497786-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-16-20-21.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21050497786-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-16-20-21.tar.gz",
     "tags": [
       "swe-bench-multimodal"
     ]
@@ -16,7 +16,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.82,
     "average_runtime": 399.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20798907628-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-08-01-39.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-20798907628-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-08-01-39.tar.gz",
     "tags": [
       "commit0"
     ]
@@ -27,7 +27,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.38,
     "average_runtime": 398.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20821586318-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-08-20-24.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-20821586318-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-08-20-24.tar.gz",
     "tags": [
       "gaia"
     ]
@@ -38,7 +38,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.42,
     "average_runtime": 343.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21179606180-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-21-03-09.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21179606180-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-21-03-09.tar.gz",
     "tags": [
       "swe-bench"
     ]
@@ -49,7 +49,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.3,
     "average_runtime": 213.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21179607467-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-21-01-44.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21179607467-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-21-01-44.tar.gz",
     "tags": [
       "swt-bench"
     ]

--- a/results/v1.8.3_gemini-3-pro/scores.json
+++ b/results/v1.8.3_gemini-3-pro/scores.json
@@ -5,7 +5,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.95,
     "average_runtime": 343.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21011486666-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-15-07-43.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21011486666-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-15-07-43.tar.gz",
     "tags": [
       "swe-bench"
     ]
@@ -16,7 +16,7 @@
     "metric": "accuracy",
     "cost_per_instance": 2.68,
     "average_runtime": 554.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20830419642-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-09-01-19.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-20830419642-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-09-01-19.tar.gz",
     "tags": [
       "commit0"
     ]
@@ -27,7 +27,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.14,
     "average_runtime": 63.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21011520577-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-15-01-50.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21011520577-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-15-01-50.tar.gz",
     "tags": [
       "gaia"
     ]
@@ -38,7 +38,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.01,
     "average_runtime": 386.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21186630675-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-21-07-16.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21186630675-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-21-07-16.tar.gz",
     "tags": [
       "swt-bench"
     ]
@@ -49,7 +49,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.74,
     "average_runtime": 877.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21225330367-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-22-01-24.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21225330367-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-22-01-24.tar.gz",
     "tags": [
       "swe-bench-multimodal"
     ]

--- a/results/v1.8.3_gpt-5.2/scores.json
+++ b/results/v1.8.3_gpt-5.2/scores.json
@@ -5,7 +5,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.69,
     "average_runtime": 1117.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21012776641-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-15-03-21.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21012776641-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-15-03-21.tar.gz",
     "tags": [
       "swe-bench-multimodal"
     ]
@@ -16,7 +16,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.86,
     "average_runtime": 476.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21010530639-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-15-04-24.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21010530639-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-15-04-24.tar.gz",
     "tags": [
       "swe-bench"
     ]
@@ -27,7 +27,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.48,
     "average_runtime": 189.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21041979432-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-15-20-40.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21041979432-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-15-20-40.tar.gz",
     "tags": [
       "gaia"
     ]
@@ -38,7 +38,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.71,
     "average_runtime": 397.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21008947912-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-14-23-44.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21008947912-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-14-23-44.tar.gz",
     "tags": [
       "commit0"
     ]
@@ -49,7 +49,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.56,
     "average_runtime": 347.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21146218648-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-19-23-58.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21146218648-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-19-23-58.tar.gz",
     "tags": [
       "swt-bench"
     ]

--- a/results/v1.8.3_kimi-k2-thinking/scores.json
+++ b/results/v1.8.3_kimi-k2-thinking/scores.json
@@ -5,7 +5,7 @@
     "metric": "accuracy",
     "cost_per_instance": 2.0,
     "average_runtime": 1325.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21078698262-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-17-16-26.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21078698262-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-17-16-26.tar.gz",
     "tags": [
       "swe-bench"
     ]
@@ -16,7 +16,7 @@
     "metric": "accuracy",
     "cost_per_instance": 6.78,
     "average_runtime": 2314.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21008948105-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-15-00-35.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21008948105-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-15-00-35.tar.gz",
     "tags": [
       "commit0"
     ]
@@ -27,7 +27,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.65,
     "average_runtime": 279.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21093372341-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-17-13-03.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21093372341-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-17-13-03.tar.gz",
     "tags": [
       "gaia"
     ]
@@ -38,7 +38,7 @@
     "metric": "accuracy",
     "cost_per_instance": 4.01,
     "average_runtime": 2444.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21047727106-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-16-09-04.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21047727106-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-16-09-04.tar.gz",
     "tags": [
       "swe-bench-multimodal"
     ]
@@ -49,7 +49,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.39,
     "average_runtime": 1253.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21173239168-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-21-08-11.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21173239168-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-21-08-11.tar.gz",
     "tags": [
       "swt-bench"
     ]

--- a/results/v1.8.3_minimax-m2.1/scores.json
+++ b/results/v1.8.3_minimax-m2.1/scores.json
@@ -5,7 +5,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.74,
     "average_runtime": 641.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21225856759-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-23-35.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21225856759-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-23-35.tar.gz",
     "tags": [
       "gaia"
     ]
@@ -16,7 +16,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.71,
     "average_runtime": 579.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21213160613-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-21-13.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21213160613-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-21-13.tar.gz",
     "tags": [
       "swe-bench"
     ]
@@ -27,7 +27,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.24,
     "average_runtime": 826.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21219066409-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-19-53.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21219066409-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-19-53.tar.gz",
     "tags": [
       "commit0"
     ]
@@ -38,7 +38,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.59,
     "average_runtime": 1352.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21226358849-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-22-02-44.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21226358849-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-22-02-44.tar.gz",
     "tags": [
       "swe-bench-multimodal"
     ]

--- a/results/v1.8.3_qwen-3-coder/scores.json
+++ b/results/v1.8.3_qwen-3-coder/scores.json
@@ -5,7 +5,7 @@
     "metric": "accuracy",
     "cost_per_instance": 2.45,
     "average_runtime": 1498.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21095153140-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-17-18-30.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21095153140-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-17-18-30.tar.gz",
     "tags": [
       "swe-bench-multimodal"
     ]
@@ -16,7 +16,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.28,
     "average_runtime": 197.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21093373009-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-17-12-54.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21093373009-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-17-12-54.tar.gz",
     "tags": [
       "gaia"
     ]
@@ -27,7 +27,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.26,
     "average_runtime": 680.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20979851181-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-14-09-02.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-20979851181-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-14-09-02.tar.gz",
     "tags": [
       "swe-bench"
     ]
@@ -38,7 +38,7 @@
     "metric": "accuracy",
     "cost_per_instance": 1.79,
     "average_runtime": 924.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-20981821017-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-14-06-17.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-20981821017-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-14-06-17.tar.gz",
     "tags": [
       "commit0"
     ]
@@ -49,7 +49,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.97,
     "average_runtime": 626.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21179579508-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-21-01-51.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/eval-21179579508-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-21-01-51.tar.gz",
     "tags": [
       "swt-bench"
     ]


### PR DESCRIPTION
## Summary

This PR migrates all `full_archive` URLs in the evaluation results from the old Google Cloud Storage format to the new CDN format.

### URL Format Change

**Old format:**
```
https://storage.googleapis.com/openhands-evaluation-results/{filename}
```

**New format:**
```
https://results.eval.all-hands.dev/{filename}
```

### Changes

- Updated 40 URLs across 9 result directories
- All URLs have been validated and are accessible

### Affected Files

| File | URLs Updated |
|------|-------------|
| `results/v1.8.2_deepseek-v3.2-reasoner/scores.json` | 2 |
| `results/v1.8.3_claude-4.5-opus/scores.json` | 4 |
| `results/v1.8.3_claude-4.5-sonnet/scores.json` | 5 |
| `results/v1.8.3_gemini-3-flash/scores.json` | 5 |
| `results/v1.8.3_gemini-3-pro/scores.json` | 5 |
| `results/v1.8.3_gpt-5.2/scores.json` | 5 |
| `results/v1.8.3_kimi-k2-thinking/scores.json` | 5 |
| `results/v1.8.3_minimax-m2.1/scores.json` | 4 |
| `results/v1.8.3_qwen-3-coder/scores.json` | 5 |

### Validation

All 40 URLs have been tested using HTTP HEAD requests and return successful responses (HTTP 200).

### Related

This change aligns with the infrastructure update where artifacts are now available at `https://results.eval.all-hands.dev/` instead of the old GCS bucket URL.

### Note on OpenHands/evaluation push_to_index

The `push_to_index` option was already removed from the SDK workflow (PR #1750), so no additional changes are needed in the evaluation infrastructure for new results.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)