### PR TITLE
Remove all swe-bench-multimodal results

### DIFF
--- a/results/v1.8.3_claude-4.5-opus/scores.json
+++ b/results/v1.8.3_claude-4.5-opus/scores.json
@@ -1,16 +1,5 @@
 [
   {
-    "benchmark": "swe-bench-multimodal",
-    "score": 26.5,
-    "metric": "accuracy",
-    "cost_per_instance": 2.55,
-    "average_runtime": 694.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21039823837-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-15-21-09.tar.gz",
-    "tags": [
-      "swe-bench-multimodal"
-    ]
-  },
-  {
     "benchmark": "commit0",
     "score": 37.5,
     "metric": "accuracy",

--- a/results/v1.8.3_claude-4.5-sonnet/scores.json
+++ b/results/v1.8.3_claude-4.5-sonnet/scores.json
@@ -33,17 +33,6 @@
     ]
   },
   {
-    "benchmark": "swe-bench-multimodal",
-    "score": 22.5,
-    "metric": "accuracy",
-    "cost_per_instance": 1.77,
-    "average_runtime": 893.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21115061696-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-18-19-23.tar.gz",
-    "tags": [
-      "swe-bench-multimodal"
-    ]
-  },
-  {
     "benchmark": "swt-bench",
     "score": 68.8,
     "metric": "accuracy",

--- a/results/v1.8.3_deepseek-v3.2-reasoner/scores.json
+++ b/results/v1.8.3_deepseek-v3.2-reasoner/scores.json
@@ -1,13 +1,1 @@
-[
-  {
-    "benchmark": "swe-bench-multimodal",
-    "score": 2.0,
-    "metric": "accuracy",
-    "cost_per_instance": 0.28,
-    "average_runtime": 2282.0,
-    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21226684010-deepseek-v_litellm_proxy-deepseek-deepseek-reasoner_26-01-22-03-07.tar.gz",
-    "tags": [
-      "swe-bench-multimodal"
-    ]
-  }
-]
+[]

--- a/results/v1.8.3_gemini-3-flash/scores.json
+++ b/results/v1.8.3_gemini-3-flash/scores.json
@@ -1,16 +1,5 @@
 [
   {
-    "benchmark": "swe-bench-multimodal",
-    "score": 4.9,
-    "metric": "accuracy",
-    "cost_per_instance": 0.77,
-    "average_runtime": 638.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21050497786-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-16-20-21.tar.gz",
-    "tags": [
-      "swe-bench-multimodal"
-    ]
-  },
-  {
     "benchmark": "commit0",
     "score": 18.8,
     "metric": "accuracy",

--- a/results/v1.8.3_gemini-3-pro/scores.json
+++ b/results/v1.8.3_gemini-3-pro/scores.json
@@ -42,16 +42,5 @@
     "tags": [
       "swt-bench"
     ]
-  },
-  {
-    "benchmark": "swe-bench-multimodal",
-    "score": 16.7,
-    "metric": "accuracy",
-    "cost_per_instance": 1.74,
-    "average_runtime": 877.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21225330367-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-22-01-24.tar.gz",
-    "tags": [
-      "swe-bench-multimodal"
-    ]
   }
 ]

--- a/results/v1.8.3_gpt-5.2/scores.json
+++ b/results/v1.8.3_gpt-5.2/scores.json
@@ -1,16 +1,5 @@
 [
   {
-    "benchmark": "swe-bench-multimodal",
-    "score": 27.5,
-    "metric": "accuracy",
-    "cost_per_instance": 1.69,
-    "average_runtime": 1117.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21012776641-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-15-03-21.tar.gz",
-    "tags": [
-      "swe-bench-multimodal"
-    ]
-  },
-  {
     "benchmark": "swe-bench",
     "score": 74.6,
     "metric": "accuracy",

--- a/results/v1.8.3_kimi-k2-thinking/scores.json
+++ b/results/v1.8.3_kimi-k2-thinking/scores.json
@@ -33,17 +33,6 @@
     ]
   },
   {
-    "benchmark": "swe-bench-multimodal",
-    "score": 10.8,
-    "metric": "accuracy",
-    "cost_per_instance": 4.01,
-    "average_runtime": 2444.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21047727106-kimi-k2-th_litellm_proxy-moonshot-kimi-k2-thinking_26-01-16-09-04.tar.gz",
-    "tags": [
-      "swe-bench-multimodal"
-    ]
-  },
-  {
     "benchmark": "swt-bench",
     "score": 47.3,
     "metric": "accuracy",

--- a/results/v1.8.3_minimax-m2.1/scores.json
+++ b/results/v1.8.3_minimax-m2.1/scores.json
@@ -31,16 +31,5 @@
     "tags": [
       "commit0"
     ]
-  },
-  {
-    "benchmark": "swe-bench-multimodal",
-    "score": 14.7,
-    "metric": "accuracy",
-    "cost_per_instance": 1.59,
-    "average_runtime": 1352.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21226358849-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-22-02-44.tar.gz",
-    "tags": [
-      "swe-bench-multimodal"
-    ]
   }
 ]

--- a/results/v1.8.3_qwen-3-coder/scores.json
+++ b/results/v1.8.3_qwen-3-coder/scores.json
@@ -1,16 +1,5 @@
 [
   {
-    "benchmark": "swe-bench-multimodal",
-    "score": 2.0,
-    "metric": "accuracy",
-    "cost_per_instance": 2.45,
-    "average_runtime": 1498.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21095153140-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-17-18-30.tar.gz",
-    "tags": [
-      "swe-bench-multimodal"
-    ]
-  },
-  {
     "benchmark": "gaia",
     "score": 33.9,
     "metric": "accuracy",


### PR DESCRIPTION
## Summary

This PR removes all `swe-bench-multimodal` benchmark results from the repository.

## Changes

Removed `swe-bench-multimodal` benchmark entries from `scores.json` files in the following directories:

| Directory | Score Removed |
|-----------|---------------|
| v1.8.3_claude-4.5-opus | 26.5% |
| v1.8.3_claude-4.5-sonnet | 22.5% |
| v1.8.3_deepseek-v3.2-reasoner | 2.0% |
| v1.8.3_gemini-3-flash | 4.9% |
| v1.8.3_gemini-3-pro | 16.7% |
| v1.8.3_gpt-5.2 | 27.5% |
| v1.8.3_kimi-k2-thinking | 10.8% |
| v1.8.3_minimax-m2.1 | 14.7% |
| v1.8.3_qwen-3-coder | 2.0% |

**Total**: 9 files modified, 101 lines removed

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)