### PR TITLE
Add swe-bench-multimodal results for gpt-5.2, claude-4.5-opus, claude-4.5-sonnet

### DIFF
--- a/results/v1.8.3_claude-4.5-opus/scores.json
+++ b/results/v1.8.3_claude-4.5-opus/scores.json
@@ -41,5 +41,16 @@
     "tags": [
       "swt-bench"
     ]
+  },
+  {
+    "benchmark": "swe-bench-multimodal",
+    "score": 25.5,
+    "metric": "accuracy",
+    "cost_per_instance": 2.74,
+    "average_runtime": 712.0,
+    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21275300173-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-23-07-23.tar.gz",
+    "tags": [
+      "swe-bench-multimodal"
+    ]
   }
 ]

--- a/results/v1.8.3_claude-4.5-sonnet/scores.json
+++ b/results/v1.8.3_claude-4.5-sonnet/scores.json
@@ -42,5 +42,16 @@
     "tags": [
       "swt-bench"
     ]
+  },
+  {
+    "benchmark": "swe-bench-multimodal",
+    "score": 23.5,
+    "metric": "accuracy",
+    "cost_per_instance": 1.78,
+    "average_runtime": 908.0,
+    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21275302419-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-23-07-14.tar.gz",
+    "tags": [
+      "swe-bench-multimodal"
+    ]
   }
 ]

--- a/results/v1.8.3_gpt-5.2/scores.json
+++ b/results/v1.8.3_gpt-5.2/scores.json
@@ -42,5 +42,16 @@
     "tags": [
       "swt-bench"
     ]
+  },
+  {
+    "benchmark": "swe-bench-multimodal",
+    "score": 30.4,
+    "metric": "accuracy",
+    "cost_per_instance": 1.56,
+    "average_runtime": 1499.0,
+    "full_archive": "https://storage.googleapis.com/openhands-evaluation-results/eval-21276042487-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-23-11-43.tar.gz",
+    "tags": [
+      "swe-bench-multimodal"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
Adds swe-bench-multimodal benchmark results for 3 models:

| Model | Accuracy | Cost/Instance | Avg Runtime |
|-------|----------|---------------|-------------|
| gpt-5.2 | 30.4% | $1.56 | 1499s |
| claude-4.5-opus | 25.5% | $2.74 | 712s |
| claude-4.5-sonnet | 23.5% | $1.78 | 908s |

## Details
These results were from evaluations that completed successfully but the Push to Index workflow created results in new directories instead of updating the existing v1.8.3_* directories. This PR manually adds the scores to the correct locations.

Archive URLs:
- gpt-5.2: `eval-21276042487-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-23-11-43.tar.gz`
- claude-4.5-opus: `eval-21275300173-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-23-07-23.tar.gz`
- claude-4.5-sonnet: `eval-21275302419-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-23-07-14.tar.gz`

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)