### PR TITLE
Add swe-bench-multimodal results for qwen-3-coder

### DIFF
--- a/results/v1.8.3_qwen-3-coder/scores.json
+++ b/results/v1.8.3_qwen-3-coder/scores.json
@@ -42,5 +42,21 @@
     "tags": [
       "swt-bench"
     ]
+  },
+  {
+    "benchmark": "swe-bench-multimodal",
+    "score": 23.5,
+    "metric": "solveable_accuracy",
+    "cost_per_instance": 2.09,
+    "average_runtime": 1006.0,
+    "full_archive": "https://results.eval.all-hands.dev/eval-21357041327-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-26-15-08.tar.gz",
+    "tags": [
+      "swe-bench-multimodal"
+    ],
+    "component_scores": {
+      "solveable_accuracy": 23.5,
+      "unsolveable_accuracy": 5.9,
+      "combined_accuracy": 17.6
+    }
   }
 ]


### PR DESCRIPTION
## Summary

This PR adds swe-bench-multimodal results for Qwen 3 Coder with solveable_accuracy scoring.

**Using eval-21357041327** (re-run with correct params)

## Scores

| Metric | Score |
|--------|-------|
| **solveable_accuracy** | **23.5%** (16/68 SOLVEABLE resolved) |
| unsolveable_accuracy | 5.9% (2/34 UNSOLVEABLE resolved) |
| combined_accuracy | 17.6% (18/102 total) |

## Component Scores

The `component_scores` object includes:
- `solveable_accuracy`: 23.5%
- `unsolveable_accuracy`: 5.9%
- `combined_accuracy`: 17.6%

## Archive

Full results: https://results.eval.all-hands.dev/eval-21357041327-qwen-3-cod_litellm_proxy-fireworks_ai-qwen3-coder-480b-a35b-instruct_26-01-26-15-08.tar.gz