### PR TITLE
Update swe-bench average_runtime for opus to 384

### DIFF
--- a/results/v1.8.3_claude-4.5-opus/scores.json
+++ b/results/v1.8.3_claude-4.5-opus/scores.json
@@ -25,7 +25,7 @@
     "benchmark": "swe-bench",
     "score": 77.6,
     "metric": "accuracy",
-    "average_runtime": 0,
+    "average_runtime": 384,
     "tags": [
       "swe-bench"
     ],


### PR DESCRIPTION
## Summary

This PR updates the `average_runtime` for the swe-bench benchmark in the claude-4.5-opus results from `0` to `384` seconds (06:24 minutes).

## Changes

- Updated `results/v1.8.3_claude-4.5-opus/scores.json` to set `average_runtime: 384` for the swe-bench entry

## Reason

The previous value of `0` was from an old result before CI. The correct average runtime is 06:24 minutes (384 seconds) as documented in the [evaluation spreadsheet](https://docs.google.com/spreadsheets/d/1wOUdFCMyY6Nt0AIqF705KN4JKOWgeI4wUGUP60krXXs/edit?gid=811504672#gid=811504672).

## Testing

- Schema validation passes
- All tests pass

Fixes #439

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1be1fe76a832470b96846ce2beb8b47d)