### PR TITLE
Add country field to metadata schema

### DIFF
--- a/results/v1.8.3_claude-4.5-opus/metadata.json
+++ b/results/v1.8.3_claude-4.5-opus/metadata.json
@@ -3,6 +3,7 @@
   "agent_version": "v1.8.3",
   "model": "claude-4.5-opus",
   "openness": "closed_api_available",
+  "country": "us",
   "tool_usage": "standard",
   "submission_time": "2026-01-27T01:24:15.735789+00:00",
   "directory_name": "v1.8.3_claude-4.5-opus",

--- a/results/v1.8.3_claude-4.5-sonnet/metadata.json
+++ b/results/v1.8.3_claude-4.5-sonnet/metadata.json
@@ -3,6 +3,7 @@
   "agent_version": "v1.8.3",
   "model": "claude-4.5-sonnet",
   "openness": "closed_api_available",
+  "country": "us",
   "tool_usage": "standard",
   "submission_time": "2026-01-26T16:02:48.428351+00:00",
   "directory_name": "v1.8.3_claude-4.5-sonnet",

--- a/results/v1.8.3_deepseek-v3.2-reasoner/metadata.json
+++ b/results/v1.8.3_deepseek-v3.2-reasoner/metadata.json
@@ -3,6 +3,7 @@
   "agent_version": "v1.8.3",
   "model": "deepseek-v3.2-reasoner",
   "openness": "open_weights",
+  "country": "cn",
   "tool_usage": "standard",
   "submission_time": "2026-01-26T15:54:51.705543+00:00",
   "directory_name": "v1.8.3_deepseek-v3.2-reasoner",

--- a/results/v1.8.3_gemini-3-flash/metadata.json
+++ b/results/v1.8.3_gemini-3-flash/metadata.json
@@ -3,6 +3,7 @@
   "agent_version": "v1.8.3",
   "model": "gemini-3-flash",
   "openness": "closed_api_available",
+  "country": "us",
   "tool_usage": "standard",
   "submission_time": "2026-01-26T15:53:51.936941+00:00",
   "directory_name": "v1.8.3_gemini-3-flash",

--- a/results/v1.8.3_gemini-3-pro/metadata.json
+++ b/results/v1.8.3_gemini-3-pro/metadata.json
@@ -3,6 +3,7 @@
   "agent_version": "v1.8.3",
   "model": "gemini-3-pro",
   "openness": "closed_api_available",
+  "country": "us",
   "tool_usage": "standard",
   "submission_time": "2026-01-26T15:55:15.726618+00:00",
   "directory_name": "v1.8.3_gemini-3-pro",

--- a/results/v1.8.3_gpt-5.2/metadata.json
+++ b/results/v1.8.3_gpt-5.2/metadata.json
@@ -3,6 +3,7 @@
   "agent_version": "v1.8.3",
   "model": "gpt-5.2",
   "openness": "closed_api_available",
+  "country": "us",
   "tool_usage": "standard",
   "submission_time": "2026-01-26T15:55:26.395894+00:00",
   "directory_name": "v1.8.3_gpt-5.2",

--- a/results/v1.8.3_kimi-k2-thinking/metadata.json
+++ b/results/v1.8.3_kimi-k2-thinking/metadata.json
@@ -3,6 +3,7 @@
   "agent_version": "v1.8.3",
   "model": "kimi-k2-thinking",
   "openness": "open_weights",
+  "country": "cn",
   "tool_usage": "standard",
   "submission_time": "2026-01-26T15:55:37.309255+00:00",
   "directory_name": "v1.8.3_kimi-k2-thinking",

--- a/results/v1.8.3_minimax-m2.1/metadata.json
+++ b/results/v1.8.3_minimax-m2.1/metadata.json
@@ -3,6 +3,7 @@
   "agent_version": "v1.8.3",
   "model": "minimax-m2.1",
   "openness": "open_weights",
+  "country": "cn",
   "tool_usage": "standard",
   "submission_time": "2026-01-26T15:55:47.616595+00:00",
   "directory_name": "v1.8.3_minimax-m2.1",

--- a/results/v1.8.3_qwen-3-coder/metadata.json
+++ b/results/v1.8.3_qwen-3-coder/metadata.json
@@ -3,6 +3,7 @@
   "agent_version": "v1.8.3",
   "model": "qwen-3-coder",
   "openness": "open_weights",
+  "country": "cn",
   "tool_usage": "standard",
   "submission_time": "2026-01-26T15:55:58.082973+00:00",
   "directory_name": "v1.8.3_qwen-3-coder",

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -24,7 +24,8 @@ class TestMetadataSchema:
         metadata = {
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.0.0",
-            "model": "gpt-5.2",  # Must be an expected model name
+            "model": "gpt-5.2",
+            "country": "us",  # Must be an expected model name
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -44,6 +45,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             # Missing agent_version
             "model": "gpt-5.2",
+            "country": "us",
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -63,6 +65,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.0.0",
             "model": "gpt-5.2",
+            "country": "us",
             "openness": "invalid_value",  # Invalid
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -75,6 +78,46 @@ class TestMetadataSchema:
         valid, msg = validate_metadata(metadata_file)
         assert valid is False
         assert "openness" in msg.lower()
+
+    def test_invalid_country_value(self, tmp_path):
+        """Test metadata with invalid country value fails validation."""
+        metadata = {
+            "agent_name": "OpenHands CodeAct",
+            "agent_version": "v1.0.0",
+            "model": "gpt-5.2",
+            "country": "invalid_country",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "submission_time": "2025-11-24T19:56:00.092865",
+            "directory_name": "v1.0.0_gpt-5.2",
+            "release_date": "2025-12-11"
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is False
+        assert "country" in msg.lower()
+
+    def test_country_mismatch_for_model(self, tmp_path):
+        """Test metadata with incorrect country for model fails validation."""
+        metadata = {
+            "agent_name": "OpenHands CodeAct",
+            "agent_version": "v1.0.0",
+            "model": "gpt-5.2",
+            "country": "cn",  # Should be "us" for GPT
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "submission_time": "2025-11-24T19:56:00.092865",
+            "directory_name": "v1.0.0_gpt-5.2",
+            "release_date": "2025-12-11"
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is False
+        assert "country" in msg.lower()
 
     def test_invalid_model_value(self, tmp_path):
         """Test metadata with invalid model value fails validation."""
@@ -101,6 +144,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.8.2",
             "model": "gpt-5.2",
+            "country": "us",
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -120,6 +164,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             "agent_version": "54c5858",  # Invalid - commit hash
             "model": "gpt-5.2",
+            "country": "us",
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -139,6 +184,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             "agent_version": "1.0.0",  # Invalid - missing 'v' prefix
             "model": "gpt-5.2",
+            "country": "us",
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -158,6 +204,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             "agent_version": "main",  # Invalid - branch name
             "model": "gpt-5.2",
+            "country": "us",
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -177,6 +224,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.8.3",
             "model": "claude-4.5-sonnet",
+            "country": "us",
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -196,6 +244,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.8.3",
             "model": "claude-4.5-sonnet",
+            "country": "us",
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -215,6 +264,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.8.3",
             "model": "claude-4.5-sonnet",
+            "country": "us",
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -234,6 +284,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.0.0",
             "model": "gpt-5.2",
+            "country": "us",
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -252,7 +303,8 @@ class TestMetadataSchema:
         metadata = {
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.0.0",
-            "model": "deepseek-v3.2-reasoner",  # Open-weights model
+            "model": "deepseek-v3.2-reasoner",
+            "country": "cn",  # Open-weights model
             "openness": "open_weights",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -273,6 +325,7 @@ class TestMetadataSchema:
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.0.0",
             "model": "deepseek-v3.2-reasoner",
+            "country": "cn",
             "openness": "open_weights",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -294,6 +347,7 @@ class TestMetadataSchema:
             "agent_version": "v1.0.0",
             "model": "kimi-k2-thinking",
             "openness": "open_weights",
+            "country": "cn",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "v1.0.0_kimi-k2-thinking",
@@ -313,7 +367,8 @@ class TestMetadataSchema:
         metadata = {
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.0.0",
-            "model": "gpt-5.2",  # Closed model
+            "model": "gpt-5.2",
+            "country": "us",  # Closed model
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
@@ -478,7 +533,8 @@ class TestValidateResultsDirectory:
         metadata = {
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.0.0",
-            "model": "gpt-5.2",  # Must be an expected model name
+            "model": "gpt-5.2",
+            "country": "us",  # Must be an expected model name
             "openness": "closed_api_available",
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",


### PR DESCRIPTION
## Summary

This PR adds a `country` field to the metadata schema to track the country of origin for each model. This will enable the OpenHands Index to display models marked by country (using flag icons) in addition to the existing company and openness markers.

## Changes

### Schema Updates (`scripts/validate_schema.py`)
- Added `Country` enum with values: `us`, `cn`, `fr`
- Added `MODEL_COUNTRY_MAP` to map models to their country of origin:
  - US models: claude-4.5-opus, claude-4.5-sonnet, gemini-3-pro, gemini-3-flash, gpt-5.2
  - China models: kimi-k2-thinking, minimax-m2.1, deepseek-v3.2-reasoner, qwen-3-coder
- Added `country` field to `Metadata` class with validation that ensures country matches the expected value for each model

### Metadata Updates
- Updated all 9 existing `metadata.json` files with the appropriate `country` field

### Test Updates (`tests/test_validate_schema.py`)
- Added `country` field to all existing test cases
- Added new test: `test_invalid_country_value` - validates that invalid country values are rejected
- Added new test: `test_country_mismatch_for_model` - validates that incorrect country-model combinations are rejected

## Testing

All 30 tests pass:
```
$ python -m pytest tests/test_validate_schema.py -v
============================== 30 passed in 0.22s ==============================
```

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)