### PR TITLE
Add gpt-5.2-codex to validate_schema.py

### DIFF
--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -48,6 +48,7 @@ class Model(str, Enum):
     GEMINI_3_PRO = "gemini-3-pro"
     GEMINI_3_FLASH = "gemini-3-flash"
     GPT_5_2 = "gpt-5.2"
+    GPT_5_2_CODEX = "gpt-5.2-codex"
     KIMI_K2_THINKING = "kimi-k2-thinking"
     MINIMAX_M2_1 = "minimax-m2.1"
     DEEPSEEK_V3_2_REASONER = "deepseek-v3.2-reasoner"
@@ -64,6 +65,7 @@ MODEL_OPENNESS_MAP: dict[Model, Openness] = {
     Model.GEMINI_3_PRO: Openness.CLOSED_API_AVAILABLE,
     Model.GEMINI_3_FLASH: Openness.CLOSED_API_AVAILABLE,
     Model.GPT_5_2: Openness.CLOSED_API_AVAILABLE,
+    Model.GPT_5_2_CODEX: Openness.CLOSED_API_AVAILABLE,
     # Open-weights models
     Model.KIMI_K2_THINKING: Openness.OPEN_WEIGHTS,
     Model.MINIMAX_M2_1: Openness.OPEN_WEIGHTS,
@@ -79,6 +81,7 @@ CLOSED_MODELS = {
     Model.GEMINI_3_PRO,
     Model.GEMINI_3_FLASH,
     Model.GPT_5_2,
+    Model.GPT_5_2_CODEX,
 }
 
 
@@ -90,6 +93,7 @@ MODEL_COUNTRY_MAP: dict[Model, Country] = {
     Model.GEMINI_3_PRO: Country.US,
     Model.GEMINI_3_FLASH: Country.US,
     Model.GPT_5_2: Country.US,
+    Model.GPT_5_2_CODEX: Country.US,
     # China models
     Model.KIMI_K2_THINKING: Country.CN,
     Model.MINIMAX_M2_1: Country.CN,

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -39,6 +39,26 @@ class TestMetadataSchema:
         assert valid is True
         assert msg == "OK"
 
+    def test_valid_metadata_gpt_5_2_codex(self, tmp_path):
+        """Test valid metadata for gpt-5.2-codex passes validation."""
+        metadata = {
+            "agent_name": "OpenHands CodeAct",
+            "agent_version": "v1.0.0",
+            "model": "gpt-5.2-codex",
+            "country": "us",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "submission_time": "2025-11-24T19:56:00.092865",
+            "directory_name": "v1.0.0_gpt-5.2-codex",
+            "release_date": "2025-12-11"
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is True
+        assert msg == "OK"
+
     def test_missing_required_field(self, tmp_path):
         """Test metadata with missing required field fails validation."""
         metadata = {


### PR DESCRIPTION
## Summary
This PR adds `gpt-5.2-codex` as a valid model in `validate_schema.py`.

## Changes
- Add `GPT_5_2_CODEX = "gpt-5.2-codex"` to the `Model` enum
- Add `gpt-5.2-codex` to `MODEL_OPENNESS_MAP` with `closed_api_available` classification
- Add `gpt-5.2-codex` to `CLOSED_MODELS` set
- Add `gpt-5.2-codex` to `MODEL_COUNTRY_MAP` with `US` country
- Add test case for validating `gpt-5.2-codex` metadata

## Testing
All 37 tests pass, including the new test for `gpt-5.2-codex`.

Fixes #463

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/72c8998754394e3081ce023e277b690b)