### PR TITLE
Make country and release_date optional in metadata schema

### DIFF
--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -299,7 +299,7 @@ class TestMetadataSchema:
         assert "directory_name" in msg.lower()
 
     def test_missing_release_date(self, tmp_path):
-        """Test metadata with missing release_date fails validation."""
+        """Test metadata with missing release_date passes validation (release_date is optional)."""
         metadata = {
             "agent_name": "OpenHands CodeAct",
             "agent_version": "v1.0.0",
@@ -309,14 +309,13 @@ class TestMetadataSchema:
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "v1.0.0_gpt-5.2"
-            # Missing release_date
+            # Missing release_date - now optional
         }
         metadata_file = tmp_path / "metadata.json"
         metadata_file.write_text(json.dumps(metadata))
 
         valid, msg = validate_metadata(metadata_file)
-        assert valid is False
-        assert "release_date" in msg.lower()
+        assert valid is True
 
     def test_open_weights_model_requires_parameter_count_b(self, tmp_path):
         """Test that open-weights models require parameter_count_b."""


### PR DESCRIPTION
## Summary

This PR makes `country` and `release_date` fields optional in the metadata schema to allow the evaluation pipeline to submit results without these fields.

## Changes

- **`country`**: Now optional. If not provided, it is auto-derived from `MODEL_COUNTRY_MAP` based on the model name.
- **`release_date`**: Now optional.

## Why

PRs like #443 (Add commit0 results for gpt-5.2-codex) are failing validation because the evaluation pipeline generates metadata.json files without `country` and `release_date` fields. This minimal change allows those PRs to pass validation while maintaining backward compatibility with existing results that include these fields.

## Testing

- All 53 tests pass
- Validated against the exact metadata.json from PR #443
- Existing results in the repository still pass validation

Fixes #463

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/96280df03dfa4bfa8e16687fea667c8c)