### PR TITLE
Show validation failure reason in workflow output

### DIFF
--- a/.github/workflows/measure-progress.yml
+++ b/.github/workflows/measure-progress.yml
@@ -78,4 +78,7 @@ jobs:
         if: steps.validate.outputs.exit_code != '0'
         run: |
           echo "Schema validation failed"
+          echo ""
+          echo "Validation output:"
+          echo "${{ steps.validate.outputs.output }}"
           exit 1


### PR DESCRIPTION
## Summary

When schema validation fails in the GitHub Actions workflow, the failure message now includes the full validation output with specific error messages, making it easier to diagnose and fix validation issues.

## Changes

- Updated `.github/workflows/measure-progress.yml` to display the validation output when the workflow fails due to schema validation errors

## Before

When validation failed, the workflow would only show:
```
Schema validation failed
```

## After

Now the workflow shows:
```
Schema validation failed

Validation output:
<full validation output with specific error messages>
```

Fixes #472

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/850f8ea4e21f4fcb91081c134a9641bc)