### PR TITLE
Improve schema validation error messages to show actual reasons for failure

### DIFF
--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -14,7 +14,40 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+
+
+def format_validation_error(error: ValidationError) -> str:
+    """Format a Pydantic ValidationError into a human-readable message.
+
+    Args:
+        error: The Pydantic ValidationError to format.
+
+    Returns:
+        A formatted string with clear error messages.
+    """
+    messages = []
+    for err in error.errors():
+        field = ".".join(str(loc) for loc in err["loc"])
+        error_type = err["type"]
+        msg = err["msg"]
+        input_value = err.get("input")
+
+        # Build a clear, human-readable message
+        if error_type == "missing":
+            messages.append(f"  • Field '{field}' is required but missing")
+        elif error_type == "enum":
+            messages.append(f"  • Field '{field}': {msg} (got: '{input_value}')")
+        elif error_type == "value_error":
+            # Extract the actual error message without "Value error, " prefix
+            clean_msg = msg.replace("Value error, ", "")
+            messages.append(f"  • Field '{field}': {clean_msg}")
+        elif error_type in ("less_than_equal", "greater_than", "greater_than_equal", "less_than"):
+            messages.append(f"  • Field '{field}': {msg} (got: {input_value})")
+        else:
+            messages.append(f"  • Field '{field}': {msg} (got: '{input_value}')")
+
+    return "\n".join(messages)
 
 SEMVER_PATTERN = re.compile(r'^v\d+\.\d+\.\d+$')
 DIRECTORY_NAME_PATTERN = re.compile(r'^v\d+\.\d+\.\d+_.+$')
@@ -247,6 +280,10 @@ def validate_metadata(file_path: Path) -> tuple[bool, str]:
         data = load_json(file_path)
         Metadata(**data)
         return True, "OK"
+    except ValidationError as e:
+        return False, format_validation_error(e)
+    except json.JSONDecodeError as e:
+        return False, f"Invalid JSON: {e.msg} at line {e.lineno}, column {e.colno}"
     except Exception as e:
         return False, str(e)
 
@@ -256,13 +293,17 @@ def validate_scores(file_path: Path) -> tuple[bool, str]:
     try:
         data = load_json(file_path)
         if not isinstance(data, list):
-            return False, "scores.json must be a list"
+            return False, "scores.json must be a list of score entries"
         for i, entry in enumerate(data):
             try:
                 ScoreEntry(**entry)
+            except ValidationError as e:
+                return False, f"Entry {i}:\n{format_validation_error(e)}"
             except Exception as e:
                 return False, f"Entry {i}: {e}"
         return True, "OK"
+    except json.JSONDecodeError as e:
+        return False, f"Invalid JSON: {e.msg} at line {e.lineno}, column {e.colno}"
     except Exception as e:
         return False, str(e)
 


### PR DESCRIPTION
## Summary

This PR fixes #472 by improving the schema validation error messages to show the actual reasons for failure, not just error codes.

## Changes

### `scripts/validate_schema.py`
- Added `format_validation_error()` function that converts Pydantic `ValidationError` into human-readable messages
- Error messages now clearly show:
  - **Missing fields**: `Field 'agent_version' is required but missing`
  - **Invalid enum values**: `Field 'model': Input should be 'claude-4.5-opus', ... (got: 'invalid-model')`
  - **Value constraints**: `Field 'score': Input should be less than or equal to 100 (got: 150)`
  - **Custom validation errors**: `Field 'agent_version': agent_version must be a valid semantic version starting with 'v' (e.g., 'v1.0.0'), got 'invalid-version'`
  - **JSON parse errors**: `Invalid JSON: Expecting ',' delimiter at line 4, column 3`
- Removed Pydantic documentation URLs from error output (they were not helpful for users)
- For `scores.json` validation, errors now show which entry failed (e.g., `Entry 1:`)

### `tests/test_validate_schema.py`
- Added `TestErrorMessageFormatting` class with 7 new tests to verify:
  - Missing field error messages are clear
  - Invalid enum errors show the invalid value
  - Value constraint errors show the actual value
  - Custom validator errors explain the validation rule
  - Invalid JSON errors show line and column
  - Scores entry errors show which entry failed
  - Error messages don't include Pydantic URLs

## Example Output

**Before:**
```
4 validation errors for Metadata
agent_version
  Value error, agent_version must be a valid semantic version starting with 'v' (e.g., 'v1.0.0'), got 'invalid-version' [type=value_error, input_value='invalid-version', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
model
  Input should be 'claude-4.5-opus', ... [type=enum, input_value='invalid-model', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/enum
```

**After:**
```
  • Field 'agent_version': agent_version must be a valid semantic version starting with 'v' (e.g., 'v1.0.0'), got 'invalid-version'
  • Field 'model': Input should be 'claude-4.5-opus', ... (got: 'invalid-model')
```

## Testing

All 60 tests pass:
```
============================== 60 passed in 0.14s ==============================
```

Fixes #472

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f813f298d2cb47c18c68ec20ab2b82a6)