### PR TITLE
Add kimi-k2.5 model to validation schema

### DIFF
--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -83,6 +83,7 @@ class Model(str, Enum):
     GPT_5_2 = "gpt-5.2"
     GPT_5_2_CODEX = "gpt-5.2-codex"
     KIMI_K2_THINKING = "kimi-k2-thinking"
+    KIMI_K2_5 = "kimi-k2.5"
     MINIMAX_M2_1 = "minimax-m2.1"
     DEEPSEEK_V3_2_REASONER = "deepseek-v3.2-reasoner"
     QWEN_3_CODER = "qwen-3-coder"
@@ -102,6 +103,7 @@ MODEL_OPENNESS_MAP: dict[Model, Openness] = {
     Model.GPT_5_2_CODEX: Openness.CLOSED_API_AVAILABLE,
     # Open-weights models
     Model.KIMI_K2_THINKING: Openness.OPEN_WEIGHTS,
+    Model.KIMI_K2_5: Openness.OPEN_WEIGHTS,
     Model.MINIMAX_M2_1: Openness.OPEN_WEIGHTS,
     Model.DEEPSEEK_V3_2_REASONER: Openness.OPEN_WEIGHTS,
     Model.QWEN_3_CODER: Openness.OPEN_WEIGHTS,
@@ -133,6 +135,7 @@ MODEL_COUNTRY_MAP: dict[Model, Country] = {
     Model.NEMOTRON: Country.US,
     # China models
     Model.KIMI_K2_THINKING: Country.CN,
+    Model.KIMI_K2_5: Country.CN,
     Model.MINIMAX_M2_1: Country.CN,
     Model.DEEPSEEK_V3_2_REASONER: Country.CN,
     Model.QWEN_3_CODER: Country.CN,

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -81,6 +81,28 @@ class TestMetadataSchema:
         assert valid is True
         assert msg == "OK"
 
+    def test_valid_metadata_kimi_k2_5(self, tmp_path):
+        """Test valid metadata for kimi-k2.5 passes validation."""
+        metadata = {
+            "agent_name": "OpenHands CodeAct",
+            "agent_version": "v1.8.3",
+            "model": "kimi-k2.5",
+            "country": "cn",
+            "openness": "open_weights",
+            "tool_usage": "standard",
+            "submission_time": "2026-01-29T10:00:00.000000+00:00",
+            "directory_name": "v1.8.3_kimi-k2.5",
+            "release_date": "2026-01-20",
+            "parameter_count_b": 1000,
+            "active_parameter_count_b": 32
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is True
+        assert msg == "OK"
+
     def test_missing_required_field(self, tmp_path):
         """Test metadata with missing required field fails validation."""
         metadata = {


### PR DESCRIPTION
## Summary
This PR adds `kimi-k2.5` to the validation script, similar to how `nemotron` was added.

## Changes
- Added `KIMI_K2_5 = "kimi-k2.5"` to the `Model` enum
- Added `kimi-k2.5` to `MODEL_OPENNESS_MAP` as `open_weights` (as specified in the issue)
- Added `kimi-k2.5` to `MODEL_COUNTRY_MAP` as `CN` (China - same as other Kimi models)
- Added test `test_valid_metadata_kimi_k2_5` to verify the new model validates correctly

## Testing
All 62 tests pass, including the new test for kimi-k2.5.

Fixes #480

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8260fc5b83f843f29121544221d770c4)