### PR TITLE
fix: Add parameter counts for nemotron-3-nano and remove redundant CLOSED_MODELS

### DIFF
--- a/results/v1.8.3_nemotron-3-nano/metadata.json
+++ b/results/v1.8.3_nemotron-3-nano/metadata.json
@@ -3,9 +3,11 @@
   "agent_version": "v1.8.3",
   "model": "nemotron-3-nano",
   "openness": "open_weights",
-  "country": "us", 
+  "country": "us",
   "tool_usage": "standard",
   "submission_time": "2026-01-27T20:00:30.624153+00:00",
   "directory_name": "v1.8.3_nemotron-3-nano",
-  "release_date": "2025-12-15"
+  "release_date": "2025-12-15",
+  "parameter_count_b": 31.6,
+  "active_parameter_count_b": 3.2
 }

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -111,18 +111,6 @@ MODEL_OPENNESS_MAP: dict[Model, Openness] = {
 }
 
 
-# Closed models where parameter count is not publicly known
-CLOSED_MODELS = {
-    Model.CLAUDE_4_5_OPUS,
-    Model.CLAUDE_4_5_SONNET,
-    Model.GEMINI_3_PRO,
-    Model.GEMINI_3_FLASH,
-    Model.GPT_5_2,
-    Model.GPT_5_2_CODEX,
-    Model.NEMOTRON_3_NANO,
-}
-
-
 # Mapping of models to their country of origin
 MODEL_COUNTRY_MAP: dict[Model, Country] = {
     # US models
@@ -218,8 +206,9 @@ class Metadata(BaseModel):
 
     @model_validator(mode='after')
     def validate_parameter_count_for_open_models(self):
-        """Ensure parameter_count_b is provided for non-closed models."""
-        if self.model not in CLOSED_MODELS and self.parameter_count_b is None:
+        """Ensure parameter_count_b is provided for open-weights models."""
+        model_openness = MODEL_OPENNESS_MAP.get(self.model)
+        if model_openness == Openness.OPEN_WEIGHTS and self.parameter_count_b is None:
             raise ValueError(
                 f"parameter_count_b is required for open-weights model '{self.model.value}'"
             )

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -72,7 +72,9 @@ class TestMetadataSchema:
             "tool_usage": "standard",
             "submission_time": "2026-01-27T20:02:11.332283+00:00",
             "directory_name": "v1.8.3_nemotron-3-nano",
-            "release_date": "2026-01-15"
+            "release_date": "2026-01-15",
+            "parameter_count_b": 31.6,
+            "active_parameter_count_b": 3.2
         }
         metadata_file = tmp_path / "metadata.json"
         metadata_file.write_text(json.dumps(metadata))


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency where `nemotron-3-nano` appeared in the first 3 graphs on the OpenHands Index page but not in the "Open Models by Parameter Size" graph.

## Root Cause

The issue was that `nemotron-3-nano` was incorrectly listed in `CLOSED_MODELS` (allowing it to skip the `parameter_count_b` requirement), even though it's defined as `OPEN_WEIGHTS` in `MODEL_OPENNESS_MAP`. The "Open Models by Parameter Size" chart filters for models where `parameter_count_b` is present, so nemotron-3-nano was excluded.

## Changes

1. **Removed `CLOSED_MODELS` from `scripts/validate_schema.py`**
   - This redundant set was used to exempt certain models from requiring `parameter_count_b`
   - Now the validator derives this directly from `MODEL_OPENNESS_MAP` - the single source of truth
   - This prevents future inconsistencies where a model's openness doesn't match its parameter requirement

2. **Updated the validator logic**
   - Changed from checking `if self.model not in CLOSED_MODELS`
   - To checking `if MODEL_OPENNESS_MAP.get(self.model) == Openness.OPEN_WEIGHTS`
   - This ensures open-weights models require `parameter_count_b`, while closed models don't

3. **Added parameter counts for `nemotron-3-nano`**
   - `parameter_count_b`: 31.6 (total parameters in billions)
   - `active_parameter_count_b`: 3.2 (active parameters for this MoE model)
   - Values sourced from [NVIDIA's official Nemotron 3 documentation](https://research.nvidia.com/labs/nemotron/Nemotron-3/)

4. **Updated the test**
   - The test for nemotron-3-nano now includes the required `parameter_count_b` field

## Verification

- All 62 tests pass
- Schema validation passes for all 22 files in the results directory

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)