### PR TITLE
Results for v1.8.3_kimi-k2.5

### DIFF
--- a/results/v1.8.3_kimi-k2.5/metadata.json
+++ b/results/v1.8.3_kimi-k2.5/metadata.json
@@ -1,0 +1,13 @@
+{
+  "agent_name": "OpenHands CodeAct",
+  "agent_version": "v1.8.3",
+  "model": "kimi-k2.5",
+  "openness": "open_weights",
+  "country": "cn",
+  "tool_usage": "standard",
+  "submission_time": "2026-01-30T23:37:19.341897+00:00",
+  "directory_name": "v1.8.3_kimi-k2.5",
+  "release_date": "2026-01-27",
+  "parameter_count_b": 1000,
+  "active_parameter_count_b": 32
+}

--- a/results/v1.8.3_kimi-k2.5/scores.json
+++ b/results/v1.8.3_kimi-k2.5/scores.json
@@ -1,0 +1,57 @@
+[
+  {
+    "benchmark": "commit0",
+    "score": 18.8,
+    "metric": "accuracy",
+    "cost_per_instance": 0.9644,
+    "average_runtime": 814.0,
+    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-moonshot-kimi-k2-5/21437607227/results.tar.gz",
+    "tags": [
+      "commit0"
+    ]
+  },
+  {
+    "benchmark": "swe-bench",
+    "score": 68.8,
+    "metric": "accuracy",
+    "cost_per_instance": 0.4768,
+    "average_runtime": 707.0,
+    "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-moonshot-kimi-k2-5/21417485547/results.tar.gz",
+    "tags": [
+      "swe-bench"
+    ]
+  },
+  {
+    "benchmark": "swt-bench",
+    "score": 54.0,
+    "metric": "accuracy",
+    "cost_per_instance": 0.24,
+    "average_runtime": 343.14,
+    "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-moonshot-kimi-k2-5/21417485547/results.tar.gz",
+    "tags": [
+      "swt-bench"
+    ]
+  },
+  {
+    "benchmark": "gaia",
+    "score": 63.6,
+    "metric": "accuracy",
+    "cost_per_instance": 0.3864,
+    "average_runtime": 602.0,
+    "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-moonshot-kimi-k2-5/21497407856/results.tar.gz",
+    "tags": [
+      "gaia"
+    ]
+  },
+  {
+    "benchmark": "swe-bench-multimodal",
+    "score": 21.6,
+    "metric": "accuracy",
+    "cost_per_instance": 1.5773,
+    "average_runtime": 921.0,
+    "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-moonshot-kimi-k2-5/21492411890/results.tar.gz",
+    "tags": [
+      "swe-bench-multimodal"
+    ]
+  }
+]


### PR DESCRIPTION
Results for Kimi-k2.5 with costs recalculated from token usage.

For calibration we first used a single instance run of swe-bench with real cost data from LiteLLM.
The closest price from [OpenRouter/Moonshot](https://openrouter.ai/moonshotai/kimi-k2.5/providers) gave an error of around 6% which we corrected by increasing cache cost from 0.1 to 0.13.

To double check, we rerun the same cost calculation with a new run of swe-bench with real cost data for 50 instances and it gave less than 1% error see https://github.com/OpenHands/openhands-index-results/pull/501/changes/51f0dc6edc8ae24e96b9840349f5a674e6cfca94

For transparency, there was one instance where we got 20% error when recalculating costs of claude sonnet 4.5
With single instance we got <1% error  https://github.com/OpenHands/openhands-index-results/pull/491/changes/516c1230eef5db84bc0b8b1c8333172df0fa82b2
but when we rerun with 500 instances we got 20% error: https://github.com/OpenHands/openhands-index-results/pull/496/changes
This might be due to Anthropic table of cost that includes more sophisticated cache pricing https://platform.claude.com/docs/en/about-claude/pricing