### PR TITLE
Add glm-4.7 to the models expected by the Schema Validation Report

### DIFF
--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -80,6 +80,7 @@ class Model(str, Enum):
     CLAUDE_4_5_SONNET = "claude-4.5-sonnet"
     GEMINI_3_PRO = "gemini-3-pro"
     GEMINI_3_FLASH = "gemini-3-flash"
+    GLM_4_7 = "glm-4.7"
     GPT_5_2 = "gpt-5.2"
     GPT_5_2_CODEX = "gpt-5.2-codex"
     KIMI_K2_THINKING = "kimi-k2-thinking"
@@ -102,6 +103,7 @@ MODEL_OPENNESS_MAP: dict[Model, Openness] = {
     Model.GPT_5_2: Openness.CLOSED_API_AVAILABLE,
     Model.GPT_5_2_CODEX: Openness.CLOSED_API_AVAILABLE,
     # Open-weights models
+    Model.GLM_4_7: Openness.OPEN_WEIGHTS,
     Model.KIMI_K2_THINKING: Openness.OPEN_WEIGHTS,
     Model.KIMI_K2_5: Openness.OPEN_WEIGHTS,
     Model.MINIMAX_M2_1: Openness.OPEN_WEIGHTS,
@@ -122,6 +124,7 @@ MODEL_COUNTRY_MAP: dict[Model, Country] = {
     Model.GPT_5_2_CODEX: Country.US,
     Model.NEMOTRON_3_NANO: Country.US,
     # China models
+    Model.GLM_4_7: Country.CN,
     Model.KIMI_K2_THINKING: Country.CN,
     Model.KIMI_K2_5: Country.CN,
     Model.MINIMAX_M2_1: Country.CN,

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -105,6 +105,27 @@ class TestMetadataSchema:
         assert valid is True
         assert msg == "OK"
 
+    def test_valid_metadata_glm_4_7(self, tmp_path):
+        """Test valid metadata for glm-4.7 passes validation."""
+        metadata = {
+            "agent_name": "OpenHands CodeAct",
+            "agent_version": "v1.8.3",
+            "model": "glm-4.7",
+            "country": "cn",
+            "openness": "open_weights",
+            "tool_usage": "standard",
+            "submission_time": "2026-01-31T10:00:00.000000+00:00",
+            "directory_name": "v1.8.3_glm-4.7",
+            "release_date": "2026-01-25",
+            "parameter_count_b": 9
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is True
+        assert msg == "OK"
+
     def test_missing_required_field(self, tmp_path):
         """Test metadata with missing required field fails validation."""
         metadata = {


### PR DESCRIPTION
## Summary

This PR adds `glm-4.7` to the models expected by the Schema Validation Report.

## Changes

- Add `GLM_4_7 = "glm-4.7"` to the `Model` enum in `scripts/validate_schema.py`
- Add `glm-4.7` to `MODEL_OPENNESS_MAP` as `open_weights` (GLM is an open-weights model from Zhipu AI)
- Add `glm-4.7` to `MODEL_COUNTRY_MAP` as `cn` (China - Zhipu AI is a Chinese company)
- Add test case `test_valid_metadata_glm_4_7` to verify the schema validation works correctly for this new model

## Testing

All 47 tests pass:
```
tests/test_validate_schema.py::TestMetadataSchema::test_valid_metadata_glm_4_7 PASSED
```

Fixes #505

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/132e546fa999490287a7efe2709e92b4)