### PR TITLE
Add hide_from_leaderboard schema field and set it for nemotron-3-nano

### DIFF
--- a/results/nemotron-3-nano/metadata.json
+++ b/results/nemotron-3-nano/metadata.json
@@ -9,5 +9,6 @@
   "directory_name": "nemotron-3-nano",
   "release_date": "2025-12-15",
   "parameter_count_b": 31.6,
-  "active_parameter_count_b": 3.2
+  "active_parameter_count_b": 3.2,
+  "hide_from_leaderboard": true
 }

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -145,6 +145,7 @@ class Metadata(BaseModel):
     release_date: date = Field(..., description="Model release date (YYYY-MM-DD)")
     parameter_count_b: Optional[float] = Field(None, description="Total model parameter count in billions. Required for open-weights models.")
     active_parameter_count_b: Optional[float] = Field(None, description="Active parameter count in billions (for MoE models)")
+    hide_from_leaderboard: bool = Field(default=False, description="Whether to hide this model from the public leaderboard")
 
     @field_validator("agent_version")
     @classmethod


### PR DESCRIPTION
## Summary

This PR adds a new `hide_from_leaderboard` field to the metadata schema and sets it to `true` for the nemotron-3-nano model.

## Changes

1. **Schema Update** (`scripts/validate_schema.py`):
   - Added `hide_from_leaderboard` boolean field to the `Metadata` schema
   - Field defaults to `false` for backward compatibility

2. **Model Configuration** (`results/nemotron-3-nano/metadata.json`):
   - Set `hide_from_leaderboard: true` for nemotron-3-nano

## Rationale

We are hiding nemotron-3-nano from the leaderboard because there are currently no similarly sized models to compare it against. Without comparable models in the same size class, displaying nemotron-3-nano on the leaderboard could give the mistaken impression that it is an inferior model, when in reality its lower benchmark scores are simply a natural consequence of its smaller model size compared to all other models on the leaderboard.

Once we have additional models in similar size ranges, we can revisit this decision and potentially unhide nemotron-3-nano to enable fair comparisons within its weight class.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)