### PR TITLE
fix: correct GPT-5.2-Codex release date to December 18, 2025

### DIFF
--- a/results/GPT-5.2-Codex/metadata.json
+++ b/results/GPT-5.2-Codex/metadata.json
@@ -7,5 +7,5 @@
   "tool_usage": "standard",
   "submission_time": "2026-01-26T23:24:40.642068+00:00",
   "directory_name": "GPT-5.2-Codex",
-  "release_date": "2025-12-11"
+  "release_date": "2025-12-18"
 }


### PR DESCRIPTION
## Summary

Corrects the release date for GPT-5.2-Codex from `2025-12-11` to `2025-12-18`.

## Issue

The metadata file incorrectly listed the release date as December 11, 2025, which is when the **GPT-5.2 base model** was released. However, **GPT-5.2-Codex** (the coding-optimized variant) was released on **December 18, 2025**.

## Source

OpenAI's official announcement confirms the December 18, 2025 release date:
- https://openai.com/index/introducing-gpt-5-2-codex/

## Changes

- Updated `results/GPT-5.2-Codex/metadata.json`: `release_date` from `2025-12-11` → `2025-12-18`

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)