### PR TITLE
Add jade-spark-2862 model to schema

### DIFF
--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -89,6 +89,7 @@ class Model(str, Enum):
     DEEPSEEK_V3_2_REASONER = "DeepSeek-V3.2-Reasoner"
     QWEN_3_CODER = "Qwen3-Coder-480B"
     NEMOTRON_3_NANO = "Nemotron-3-Nano"
+    JADE_SPARK_2862 = "jade-spark-2862"
 
 
 # Mapping of models to their correct openness classification
@@ -111,6 +112,7 @@ MODEL_OPENNESS_MAP: dict[Model, Openness] = {
     Model.DEEPSEEK_V3_2_REASONER: Openness.OPEN_WEIGHTS,
     Model.QWEN_3_CODER: Openness.OPEN_WEIGHTS,
     Model.NEMOTRON_3_NANO: Openness.OPEN_WEIGHTS,
+    Model.JADE_SPARK_2862: Openness.OPEN_WEIGHTS,
 }
 
 
@@ -125,6 +127,7 @@ MODEL_COUNTRY_MAP: dict[Model, Country] = {
     Model.GPT_5_2: Country.US,
     Model.GPT_5_2_CODEX: Country.US,
     Model.NEMOTRON_3_NANO: Country.US,
+    Model.JADE_SPARK_2862: Country.US,
     # China models
     Model.GLM_4_7: Country.CN,
     Model.KIMI_K2_THINKING: Country.CN,


### PR DESCRIPTION
## Summary

Add jade-spark-2862 model to the validation schema to support the evaluation results.

## Changes

- Add `jade-spark-2862` to Model enum
- Set openness to `open_weights`
- Set country to `us`

## Related PRs

This PR needs to be merged before the following jade-spark-2862 result PRs can pass validation:
- #549 - swe-bench
- #550 - swt-bench
- #551 - swe-bench-multimodal
- #552 - gaia
- #553 - gaia (duplicate, should be closed)
- #554 - commit0

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)