### PR TITLE
Recalculate gaia costs ($0.0558/instance)

### DIFF
--- a/results/jade-spark-2862/scores.json
+++ b/results/jade-spark-2862/scores.json
@@ -12,14 +12,14 @@
     "agent_version": "v0.38.0",
     "submission_time": "2026-02-11T10:21:38+00:00",
     "eval_visualization_page": "https://laminar.sh/shared/evals/92b96069-83ec-4a5c-9319-dd35746ae198"
-    },
-    {
+  },
+  {
     "benchmark": "gaia",
     "score": 47.9,
     "metric": "accuracy",
-    "cost_per_instance": 0.01,
+    "cost_per_instance": 0.0558,
     "average_runtime": 716.0,
-    "full_archive": "https://results.eval.all-hands.dev/gaia/jade-spark-2862/21896759788/results.tar.gz",
+    "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-jade-spark-2862/21896759788/results.tar.gz",
     "tags": [
       "gaia"
     ],


### PR DESCRIPTION
## 🧮 Cost Recalculation for **gaia**

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 163 |
| **Total prompt tokens** | 179,207,970 |
| **Cache read tokens** | 170,252,793 |
| **Non-cached prompt tokens** | 8,955,177 |
| **Completion tokens** | 1,653,641 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.27 |
| Input (cache hit) | $0.03 |
| Output | $0.95 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 8,955,177 | $0.27/M | $2.4179 |
| Cached input | 170,252,793 | $0.03/M | $5.1076 |
| Output | 1,653,641 | $0.95/M | $1.5710 |
| **Total** | | | **$9.0964** |

### Final Result
- **Total cost**: $9.0964
- **Average cost per instance**: $0.0558

---
*This comment was automatically generated by the recalculate-costs action.*
