### PR TITLE
Recalculate swe-bench costs ($0.1254/instance)

### DIFF
--- a/results/MiniMax-M2.1/scores.json
+++ b/results/MiniMax-M2.1/scores.json
@@ -16,7 +16,7 @@
     "benchmark": "swe-bench",
     "score": 68.8,
     "metric": "accuracy",
-    "cost_per_instance": 0.71,
+    "cost_per_instance": 0.1254,
     "average_runtime": 579.0,
     "full_archive": "https://results.eval.all-hands.dev/eval-21213160613-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-21-13.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **swe-bench**

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 497 |
| **Total prompt tokens** | 1,068,422,954 |
| **Cache read tokens** | 988,392,339 |
| **Non-cached prompt tokens** | 80,030,615 |
| **Completion tokens** | 11,625,548 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.27 |
| Input (cache hit) | $0.03 |
| Output | $0.95 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 80,030,615 | $0.27/M | $21.6083 |
| Cached input | 988,392,339 | $0.03/M | $29.6518 |
| Output | 11,625,548 | $0.95/M | $11.0443 |
| **Total** | | | **$62.3043** |

### Final Result
- **Total cost**: $62.3043
- **Average cost per instance**: $0.1254

---
*This comment was automatically generated by the recalculate-costs action.*
