### PR TITLE
Recalculate swe-bench-multimodal costs ($0.1963/instance)

### DIFF
--- a/results/MiniMax-M2.1/scores.json
+++ b/results/MiniMax-M2.1/scores.json
@@ -55,7 +55,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 16.2,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 1.26,
+    "cost_per_instance": 0.1963,
     "average_runtime": 1417.0,
     "full_archive": "https://results.eval.all-hands.dev/eval-21324690733-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-25-06-38.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **swe-bench-multimodal**

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 101 |
| **Total prompt tokens** | 358,555,908 |
| **Cache read tokens** | 333,906,339 |
| **Non-cached prompt tokens** | 24,649,569 |
| **Completion tokens** | 3,315,104 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.27 |
| Input (cache hit) | $0.03 |
| Output | $0.95 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 24,649,569 | $0.27/M | $6.6554 |
| Cached input | 333,906,339 | $0.03/M | $10.0172 |
| Output | 3,315,104 | $0.95/M | $3.1493 |
| **Total** | | | **$19.8219** |

### Final Result
- **Total cost**: $19.8219
- **Average cost per instance**: $0.1963

---
*This comment was automatically generated by the recalculate-costs action.*
