### PR TITLE
Recalculate GLM-4.7 swe-bench-multimodal costs ($0.1017/instance)

### DIFF
--- a/results/GLM-4.7/scores.json
+++ b/results/GLM-4.7/scores.json
@@ -16,7 +16,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 22.1,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 0.66,
+    "cost_per_instance": 0.1017,
     "average_runtime": 1519.0,
     "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-openrouter-z-ai-glm-4-7/21674056150/results.tar.gz",
     "tags": [
@@ -46,8 +46,8 @@
     ],
     "agent_version": "v1.10.0",
     "submission_time": "2026-02-01T09:50:58+00:00"
-},
-{
+  },
+  {
     "benchmark": "swt-bench",
     "score": 49.4,
     "metric": "accuracy",
@@ -59,8 +59,8 @@
     ],
     "agent_version": "v1.10.0",
     "submission_time": "2026-02-01T04:32:01+00:00"
-},
-{
+  },
+  {
     "benchmark": "gaia",
     "score": 53.9,
     "metric": "accuracy",


### PR DESCRIPTION
## 🧮 Cost Recalculation for **swe-bench-multimodal**

**Archive URL:** https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-openrouter-z-ai-glm-4-7/21674056150/results.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 8 |
| **Total prompt tokens** | 4,076,071 |
| **Cache read tokens** | 3,452,253 |
| **Non-cached prompt tokens** | 623,818 |
| **Completion tokens** | 27,112 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.60 |
| Input (cache hit) | $0.11 |
| Output | $2.20 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 623,818 | $0.60/M | $0.3743 |
| Cached input | 3,452,253 | $0.11/M | $0.3797 |
| Output | 27,112 | $2.20/M | $0.0596 |
| **Total** | | | **$0.8137** |

### Final Result
- **Total cost**: $0.8137
- **Average cost per instance**: $0.1017

---
*This comment was automatically generated by the recalculate-costs action.*
