### PR TITLE
Recalculate Kimi-K2.5 commit0 costs ($0.9606/instance)

### DIFF
--- a/results/Kimi-K2.5/scores.json
+++ b/results/Kimi-K2.5/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "commit0",
     "score": 18.8,
     "metric": "accuracy",
-    "cost_per_instance": 0.9644,
+    "cost_per_instance": 0.9606,
     "average_runtime": 814.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-moonshot-kimi-k2-5/21437607227/results.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **commit0**

**Archive URL:** https://results.eval.all-hands.dev/commit0/litellm_proxy-moonshot-kimi-k2-5/21437607227/results.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 15 |
| **Total prompt tokens** | 96,391,606 |
| **Cache read tokens** | 94,768,896 |
| **Non-cached prompt tokens** | 1,622,710 |
| **Completion tokens** | 371,852 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.60 |
| Input (cache hit) | $0.13 |
| Output | $3.00 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 1,622,710 | $0.60/M | $0.9736 |
| Cached input | 94,768,896 | $0.13/M | $12.3200 |
| Output | 371,852 | $3.00/M | $1.1156 |
| **Total** | | | **$14.4091** |

### Final Result
- **Total cost**: $14.4091
- **Average cost per instance**: $0.9606

---
*This comment was automatically generated by the recalculate-costs action.*
