### PR TITLE
Recalculate GLM-4.7 swe-bench costs ($0.6507/instance)

### DIFF
--- a/results/GLM-4.7/scores.json
+++ b/results/GLM-4.7/scores.json
@@ -38,7 +38,7 @@
     "benchmark": "swe-bench",
     "score": 73.4,
     "metric": "accuracy",
-    "cost_per_instance": 0.51,
+    "cost_per_instance": 0.6507,
     "average_runtime": 1007.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-openrouter-z-ai-glm-4-7/21547894190/results.tar.gz",
     "tags": [
@@ -46,8 +46,8 @@
     ],
     "agent_version": "v1.10.0",
     "submission_time": "2026-02-01T09:50:58+00:00"
-},
-{
+  },
+  {
     "benchmark": "swt-bench",
     "score": 49.4,
     "metric": "accuracy",
@@ -59,8 +59,8 @@
     ],
     "agent_version": "v1.10.0",
     "submission_time": "2026-02-01T04:32:01+00:00"
-},
-{
+  },
+  {
     "benchmark": "gaia",
     "score": 53.9,
     "metric": "accuracy",


### PR DESCRIPTION
## 🧮 Cost Recalculation for **swe-bench**

**Archive URL:** https://results.eval.all-hands.dev/swebench/litellm_proxy-openrouter-z-ai-glm-4-7/21547894190/results.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 499 |
| **Total prompt tokens** | 1,870,429,834 |
| **Cache read tokens** | 1,776,131,594 |
| **Non-cached prompt tokens** | 94,298,240 |
| **Completion tokens** | 12,409,134 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.60 |
| Input (cache hit) | $0.13 |
| Output | $3.00 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 94,298,240 | $0.60/M | $56.5789 |
| Cached input | 1,776,131,594 | $0.13/M | $230.8971 |
| Output | 12,409,134 | $3.00/M | $37.2274 |
| **Total** | | | **$324.7035** |

### Final Result
- **Total cost**: $324.7035
- **Average cost per instance**: $0.6507

---
*This comment was automatically generated by the recalculate-costs action.*
