### PR TITLE
Recalculate MiniMax-M2.1 commit0 costs ($0.3265/instance)

### DIFF
--- a/results/MiniMax-M2.1/scores.json
+++ b/results/MiniMax-M2.1/scores.json
@@ -29,7 +29,7 @@
     "benchmark": "commit0",
     "score": 25.0,
     "metric": "accuracy",
-    "cost_per_instance": 1.24,
+    "cost_per_instance": 0.3265,
     "average_runtime": 826.0,
     "full_archive": "https://results.eval.all-hands.dev/eval-21219066409-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-19-53.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **commit0**

**Archive URL:** https://results.eval.all-hands.dev/eval-21219066409-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-19-53.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 15 |
| **Total prompt tokens** | 79,322,634 |
| **Cache read tokens** | 74,271,656 |
| **Non-cached prompt tokens** | 5,050,978 |
| **Completion tokens** | 962,077 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.30 |
| Input (cache hit) | $0.03 |
| Output | $1.20 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 5,050,978 | $0.30/M | $1.5153 |
| Cached input | 74,271,656 | $0.03/M | $2.2281 |
| Output | 962,077 | $1.20/M | $1.1545 |
| **Total** | | | **$4.8979** |

### Final Result
- **Total cost**: $4.8979
- **Average cost per instance**: $0.3265

---
*This comment was automatically generated by the recalculate-costs action.*
