### PR TITLE
Recalculate MiniMax-M2.1 gaia costs ($0.0604/instance)

### DIFF
--- a/results/MiniMax-M2.1/scores.json
+++ b/results/MiniMax-M2.1/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "gaia",
     "score": 40.6,
     "metric": "accuracy",
-    "cost_per_instance": 0.74,
+    "cost_per_instance": 0.0604,
     "average_runtime": 641.0,
     "full_archive": "https://results.eval.all-hands.dev/eval-21225856759-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-23-35.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **gaia**

**Archive URL:** https://results.eval.all-hands.dev/eval-21225856759-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-23-35.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 163 |
| **Total prompt tokens** | 141,634,673 |
| **Cache read tokens** | 126,674,025 |
| **Non-cached prompt tokens** | 14,960,648 |
| **Completion tokens** | 1,302,459 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.30 |
| Input (cache hit) | $0.03 |
| Output | $1.20 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 14,960,648 | $0.30/M | $4.4882 |
| Cached input | 126,674,025 | $0.03/M | $3.8002 |
| Output | 1,302,459 | $1.20/M | $1.5630 |
| **Total** | | | **$9.8514** |

### Final Result
- **Total cost**: $9.8514
- **Average cost per instance**: $0.0604

---
*This comment was automatically generated by the recalculate-costs action.*
