### PR TITLE
Recalculate MiniMax-M2.1 swt-bench costs ($0.1077/instance)

### DIFF
--- a/results/MiniMax-M2.1/scores.json
+++ b/results/MiniMax-M2.1/scores.json
@@ -42,7 +42,7 @@
     "benchmark": "swt-bench",
     "score": 61.4,
     "metric": "accuracy",
-    "cost_per_instance": 0.54,
+    "cost_per_instance": 0.1077,
     "average_runtime": 473.0,
     "full_archive": "https://results.eval.all-hands.dev/eval-21226206260-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-23-09-13.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **swt-bench**

**Archive URL:** https://results.eval.all-hands.dev/eval-21226206260-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-23-09-13.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 433 |
| **Total prompt tokens** | 723,883,374 |
| **Cache read tokens** | 665,805,550 |
| **Non-cached prompt tokens** | 58,077,824 |
| **Completion tokens** | 7,691,186 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.30 |
| Input (cache hit) | $0.03 |
| Output | $1.20 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 58,077,824 | $0.30/M | $17.4233 |
| Cached input | 665,805,550 | $0.03/M | $19.9742 |
| Output | 7,691,186 | $1.20/M | $9.2294 |
| **Total** | | | **$46.6269** |

### Final Result
- **Total cost**: $46.6269
- **Average cost per instance**: $0.1077

---
*This comment was automatically generated by the recalculate-costs action.*
