### PR TITLE
Recalculate jade-spark-2862 commit0 costs ($0.1627/instance)

### DIFF
--- a/results/jade-spark-2862/scores.json
+++ b/results/jade-spark-2862/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "commit0",
     "score": 50.0,
     "metric": "accuracy",
-    "cost_per_instance": 0.01,
+    "cost_per_instance": 0.1627,
     "average_runtime": 376.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-jade-spark-2862/21897034430/results.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **commit0**

**Archive URL:** https://results.eval.all-hands.dev/commit0/litellm_proxy-jade-spark-2862/21897034430/results.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 16 |
| **Total prompt tokens** | 57,457,836 |
| **Cache read tokens** | 55,558,151 |
| **Non-cached prompt tokens** | 1,899,685 |
| **Completion tokens** | 305,425 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.30 |
| Input (cache hit) | $0.03 |
| Output | $1.20 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 1,899,685 | $0.30/M | $0.5699 |
| Cached input | 55,558,151 | $0.03/M | $1.6667 |
| Output | 305,425 | $1.20/M | $0.3665 |
| **Total** | | | **$2.6032** |

### Final Result
- **Total cost**: $2.6032
- **Average cost per instance**: $0.1627

---
*This comment was automatically generated by the recalculate-costs action.*
