### PR TITLE
Recalculate jade-spark-2862 gaia costs ($0.0600/instance)

### DIFF
--- a/results/jade-spark-2862/scores.json
+++ b/results/jade-spark-2862/scores.json
@@ -17,7 +17,7 @@
     "benchmark": "gaia",
     "score": 47.9,
     "metric": "accuracy",
-    "cost_per_instance": 0.01,
+    "cost_per_instance": 0.06,
     "average_runtime": 716.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-jade-spark-2862/21896759788/results.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **gaia**

**Archive URL:** https://results.eval.all-hands.dev/gaia/litellm_proxy-jade-spark-2862/21896759788/results.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 163 |
| **Total prompt tokens** | 179,207,970 |
| **Cache read tokens** | 170,252,793 |
| **Non-cached prompt tokens** | 8,955,177 |
| **Completion tokens** | 1,653,641 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.30 |
| Input (cache hit) | $0.03 |
| Output | $1.20 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 8,955,177 | $0.30/M | $2.6866 |
| Cached input | 170,252,793 | $0.03/M | $5.1076 |
| Output | 1,653,641 | $1.20/M | $1.9844 |
| **Total** | | | **$9.7785** |

### Final Result
- **Total cost**: $9.7785
- **Average cost per instance**: $0.0600

---
*This comment was automatically generated by the recalculate-costs action.*
