### PR TITLE
Recalculate jade-spark-2862 swe-bench costs ($0.0993/instance)

### DIFF
--- a/results/jade-spark-2862/scores.json
+++ b/results/jade-spark-2862/scores.json
@@ -31,7 +31,7 @@
     "benchmark": "swe-bench",
     "score": 72.6,
     "metric": "accuracy",
-    "cost_per_instance": 0.01,
+    "cost_per_instance": 0.0993,
     "average_runtime": 455.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-jade-spark-2862/21885618644/results.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **swe-bench**

**Archive URL:** https://results.eval.all-hands.dev/swebench/litellm_proxy-jade-spark-2862/21885618644/results.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 500 |
| **Total prompt tokens** | 948,474,910 |
| **Cache read tokens** | 906,985,378 |
| **Non-cached prompt tokens** | 41,489,532 |
| **Completion tokens** | 8,342,922 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.30 |
| Input (cache hit) | $0.03 |
| Output | $1.20 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 41,489,532 | $0.30/M | $12.4469 |
| Cached input | 906,985,378 | $0.03/M | $27.2096 |
| Output | 8,342,922 | $1.20/M | $10.0115 |
| **Total** | | | **$49.6679** |

### Final Result
- **Total cost**: $49.6679
- **Average cost per instance**: $0.0993

---
*This comment was automatically generated by the recalculate-costs action.*
