### PR TITLE
Recalculate jade-spark-2862 swe-bench-multimodal costs ($0.1464/instance)

### DIFF
--- a/results/jade-spark-2862/scores.json
+++ b/results/jade-spark-2862/scores.json
@@ -59,7 +59,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 25.0,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 0.01,
+    "cost_per_instance": 0.1464,
     "average_runtime": 611.0,
     "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-jade-spark-2862/21900356665/results.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **swe-bench-multimodal**

**Archive URL:** https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-jade-spark-2862/21900356665/results.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 101 |
| **Total prompt tokens** | 327,624,406 |
| **Cache read tokens** | 319,132,673 |
| **Non-cached prompt tokens** | 8,491,733 |
| **Completion tokens** | 2,217,757 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.30 |
| Input (cache hit) | $0.03 |
| Output | $1.20 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 8,491,733 | $0.30/M | $2.5475 |
| Cached input | 319,132,673 | $0.03/M | $9.5740 |
| Output | 2,217,757 | $1.20/M | $2.6613 |
| **Total** | | | **$14.7828** |

### Final Result
- **Total cost**: $14.7828
- **Average cost per instance**: $0.1464

---
*This comment was automatically generated by the recalculate-costs action.*
