### PR TITLE
Recalculate jade-spark-2862 swt-bench costs ($0.0728/instance)

### DIFF
--- a/results/jade-spark-2862/scores.json
+++ b/results/jade-spark-2862/scores.json
@@ -45,7 +45,7 @@
     "benchmark": "swt-bench",
     "score": 68.1,
     "metric": "accuracy",
-    "cost_per_instance": 0.01,
+    "cost_per_instance": 0.0728,
     "average_runtime": 389.0,
     "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-jade-spark-2862/21870831025/results.tar.gz",
     "tags": [


### PR DESCRIPTION
## 🧮 Cost Recalculation for **swt-bench**

**Archive URL:** https://results.eval.all-hands.dev/swtbench/litellm_proxy-jade-spark-2862/21870831025/results.tar.gz

### Token Usage Summary
| Metric | Value |
|--------|-------|
| **Instances processed** | 433 |
| **Total prompt tokens** | 606,829,702 |
| **Cache read tokens** | 579,486,057 |
| **Non-cached prompt tokens** | 27,343,645 |
| **Completion tokens** | 4,940,012 |

### Pricing Used
| Token Type | Cost per Million |
|------------|------------------|
| Input (cache miss) | $0.30 |
| Input (cache hit) | $0.03 |
| Output | $1.20 |

### Cost Breakdown
| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 27,343,645 | $0.30/M | $8.2031 |
| Cached input | 579,486,057 | $0.03/M | $17.3846 |
| Output | 4,940,012 | $1.20/M | $5.9280 |
| **Total** | | | **$31.5157** |

### Final Result
- **Total cost**: $31.5157
- **Average cost per instance**: $0.0728

---
*This comment was automatically generated by the recalculate-costs action.*
