### PR TITLE
Add supports_vision field to metadata.json files

### DIFF
--- a/results/DeepSeek-V3.2-Reasoner/metadata.json
+++ b/results/DeepSeek-V3.2-Reasoner/metadata.json
@@ -8,5 +8,6 @@
   "submission_time": "2026-01-27T18:40:51.252521+00:00",
   "directory_name": "DeepSeek-V3.2-Reasoner",
   "release_date": "2025-12-01",
-  "parameter_count_b": 685
+  "parameter_count_b": 685,
+  "supports_vision": false
 }

--- a/results/GLM-4.7/metadata.json
+++ b/results/GLM-4.7/metadata.json
@@ -9,5 +9,6 @@
   "directory_name": "GLM-4.7",
   "release_date": "2025-12-22",
   "parameter_count_b": 355,
-  "active_parameter_count_b": 32
+  "active_parameter_count_b": 32,
+  "supports_vision": false
 }

--- a/results/GPT-5.2-Codex/metadata.json
+++ b/results/GPT-5.2-Codex/metadata.json
@@ -7,5 +7,6 @@
   "tool_usage": "standard",
   "submission_time": "2026-01-26T23:24:40.642068+00:00",
   "directory_name": "GPT-5.2-Codex",
-  "release_date": "2025-12-18"
+  "release_date": "2025-12-18",
+  "supports_vision": true
 }

--- a/results/GPT-5.2/metadata.json
+++ b/results/GPT-5.2/metadata.json
@@ -7,5 +7,6 @@
   "tool_usage": "standard",
   "submission_time": "2026-01-26T15:55:26.395894+00:00",
   "directory_name": "GPT-5.2",
-  "release_date": "2025-12-11"
+  "release_date": "2025-12-11",
+  "supports_vision": true
 }

--- a/results/Gemini-3-Flash/metadata.json
+++ b/results/Gemini-3-Flash/metadata.json
@@ -7,5 +7,6 @@
   "tool_usage": "standard",
   "submission_time": "2026-01-26T15:53:51.936941+00:00",
   "directory_name": "Gemini-3-Flash",
-  "release_date": "2025-12-22"
+  "release_date": "2025-12-22",
+  "supports_vision": true
 }

--- a/results/Gemini-3-Pro/metadata.json
+++ b/results/Gemini-3-Pro/metadata.json
@@ -7,5 +7,6 @@
   "tool_usage": "standard",
   "submission_time": "2026-01-26T15:55:15.726618+00:00",
   "directory_name": "Gemini-3-Pro",
-  "release_date": "2025-11-18"
+  "release_date": "2025-11-18",
+  "supports_vision": true
 }

--- a/results/Kimi-K2-Thinking/metadata.json
+++ b/results/Kimi-K2-Thinking/metadata.json
@@ -9,5 +9,6 @@
   "directory_name": "Kimi-K2-Thinking",
   "release_date": "2025-11-06",
   "parameter_count_b": 1000,
-  "active_parameter_count_b": 32
+  "active_parameter_count_b": 32,
+  "supports_vision": false
 }

--- a/results/Kimi-K2.5/metadata.json
+++ b/results/Kimi-K2.5/metadata.json
@@ -9,5 +9,6 @@
   "directory_name": "Kimi-K2.5",
   "release_date": "2026-01-27",
   "parameter_count_b": 1000,
-  "active_parameter_count_b": 32
+  "active_parameter_count_b": 32,
+  "supports_vision": true
 }

--- a/results/MiniMax-M2.1/metadata.json
+++ b/results/MiniMax-M2.1/metadata.json
@@ -9,5 +9,6 @@
   "directory_name": "MiniMax-M2.1",
   "release_date": "2025-12-23",
   "parameter_count_b": 230,
-  "active_parameter_count_b": 10
+  "active_parameter_count_b": 10,
+  "supports_vision": false
 }

--- a/results/MiniMax-M2.5/metadata.json
+++ b/results/MiniMax-M2.5/metadata.json
@@ -9,5 +9,6 @@
   "release_date": "2026-02-11",
   "country": "cn",
   "parameter_count_b": 230,
-  "active_parameter_count_b": 10
+  "active_parameter_count_b": 10,
+  "supports_vision": false
 }

--- a/results/Nemotron-3-Nano/metadata.json
+++ b/results/Nemotron-3-Nano/metadata.json
@@ -10,5 +10,6 @@
   "release_date": "2025-12-15",
   "parameter_count_b": 31.6,
   "active_parameter_count_b": 3.2,
-  "hide_from_leaderboard": true
+  "hide_from_leaderboard": true,
+  "supports_vision": false
 }

--- a/results/Qwen3-Coder-480B/metadata.json
+++ b/results/Qwen3-Coder-480B/metadata.json
@@ -9,5 +9,6 @@
   "directory_name": "Qwen3-Coder-480B",
   "release_date": "2025-07-23",
   "parameter_count_b": 480,
-  "active_parameter_count_b": 35
+  "active_parameter_count_b": 35,
+  "supports_vision": false
 }

--- a/results/claude-opus-4-5/metadata.json
+++ b/results/claude-opus-4-5/metadata.json
@@ -7,5 +7,6 @@
   "tool_usage": "standard",
   "submission_time": "2026-01-27T01:24:15.735789+00:00",
   "directory_name": "claude-opus-4-5",
-  "release_date": "2025-11-24"
+  "release_date": "2025-11-24",
+  "supports_vision": true
 }

--- a/results/claude-opus-4-6/metadata.json
+++ b/results/claude-opus-4-6/metadata.json
@@ -7,5 +7,6 @@
   "tool_usage": "standard",
   "submission_time": "2026-02-09T01:41:16.609835+00:00",
   "directory_name": "claude-opus-4-6",
-  "release_date": "2026-02-05"
+  "release_date": "2026-02-05",
+  "supports_vision": true
 }

--- a/results/claude-sonnet-4-5/metadata.json
+++ b/results/claude-sonnet-4-5/metadata.json
@@ -7,5 +7,6 @@
   "tool_usage": "standard",
   "submission_time": "2026-01-26T16:02:48.428351+00:00",
   "directory_name": "claude-sonnet-4-5",
-  "release_date": "2025-09-29"
+  "release_date": "2025-09-29",
+  "supports_vision": true
 }

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -149,6 +149,7 @@ class Metadata(BaseModel):
     submission_time: datetime = Field(..., description="Submission timestamp")
     directory_name: str = Field(..., description="Directory name for this result")
     release_date: date = Field(..., description="Model release date (YYYY-MM-DD)")
+    supports_vision: bool = Field(..., description="Whether the model supports vision/image inputs")
     parameter_count_b: Optional[float] = Field(None, description="Total model parameter count in billions. Required for open-weights models.")
     active_parameter_count_b: Optional[float] = Field(None, description="Active parameter count in billions (for MoE models)")
     hide_from_leaderboard: bool = Field(default=False, description="Whether to hide this model from the public leaderboard")

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -32,7 +32,8 @@ class TestMetadataSchema:
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "GPT-5.2",
-            "release_date": "2025-12-11"
+            "release_date": "2025-12-11",
+            "supports_vision": True
         }
         metadata_file = tmp_path / "metadata.json"
         metadata_file.write_text(json.dumps(metadata))
@@ -52,7 +53,8 @@ class TestMetadataSchema:
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "GPT-5.2-Codex",
-            "release_date": "2025-12-11"
+            "release_date": "2025-12-11",
+            "supports_vision": True
         }
         metadata_file = tmp_path / "metadata.json"
         metadata_file.write_text(json.dumps(metadata))
@@ -73,6 +75,7 @@ class TestMetadataSchema:
             "submission_time": "2026-01-27T20:02:11.332283+00:00",
             "directory_name": "Nemotron-3-Nano",
             "release_date": "2026-01-15",
+            "supports_vision": False,
             "parameter_count_b": 31.6,
             "active_parameter_count_b": 3.2
         }
@@ -95,6 +98,7 @@ class TestMetadataSchema:
             "submission_time": "2026-01-29T10:00:00.000000+00:00",
             "directory_name": "Kimi-K2.5",
             "release_date": "2026-01-20",
+            "supports_vision": True,
             "parameter_count_b": 1000,
             "active_parameter_count_b": 32
         }
@@ -117,6 +121,7 @@ class TestMetadataSchema:
             "submission_time": "2026-01-31T10:00:00.000000+00:00",
             "directory_name": "GLM-4.7",
             "release_date": "2026-01-25",
+            "supports_vision": False,
             "parameter_count_b": 9
         }
         metadata_file = tmp_path / "metadata.json"
@@ -138,6 +143,7 @@ class TestMetadataSchema:
             "submission_time": "2026-02-11T15:10:02.513451+00:00",
             "directory_name": "MiniMax-M2.5",
             "release_date": "2026-02-11",
+            "supports_vision": False,
             "parameter_count_b": 230,
             "active_parameter_count_b": 10
         }
@@ -258,7 +264,8 @@ class TestMetadataSchema:
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "GPT-5.2",
-            "release_date": "2025-12-11"
+            "release_date": "2025-12-11",
+            "supports_vision": True
         }
         metadata_file = tmp_path / "metadata.json"
         metadata_file.write_text(json.dumps(metadata))
@@ -338,7 +345,8 @@ class TestMetadataSchema:
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "claude-sonnet-4-5",
-            "release_date": "2025-09-29"
+            "release_date": "2025-09-29",
+            "supports_vision": True
         }
         metadata_file = tmp_path / "metadata.json"
         metadata_file.write_text(json.dumps(metadata))
@@ -418,7 +426,8 @@ class TestMetadataSchema:
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "DeepSeek-V3.2-Reasoner",
-            "release_date": "2025-12-01"
+            "release_date": "2025-12-01",
+            "supports_vision": False
             # Missing parameter_count_b - should fail for open-weights model
         }
         metadata_file = tmp_path / "metadata.json"
@@ -440,6 +449,7 @@ class TestMetadataSchema:
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "DeepSeek-V3.2-Reasoner",
             "release_date": "2025-12-01",
+            "supports_vision": False,
             "parameter_count_b": 685
         }
         metadata_file = tmp_path / "metadata.json"
@@ -461,6 +471,7 @@ class TestMetadataSchema:
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "Kimi-K2-Thinking",
             "release_date": "2025-11-06",
+            "supports_vision": False,
             "parameter_count_b": 1000,
             "active_parameter_count_b": 32
         }
@@ -482,7 +493,8 @@ class TestMetadataSchema:
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "GPT-5.2",
-            "release_date": "2025-12-11"
+            "release_date": "2025-12-11",
+            "supports_vision": True
             # No parameter_count_b - should be OK for closed model
         }
         metadata_file = tmp_path / "metadata.json"
@@ -491,6 +503,27 @@ class TestMetadataSchema:
         valid, msg = validate_metadata(metadata_file)
         assert valid is True
         assert msg == "OK"
+
+    def test_missing_supports_vision(self, tmp_path):
+        """Test metadata with missing supports_vision fails validation."""
+        metadata = {
+            "agent_name": "OpenHands CodeAct",
+            "agent_version": "v1.0.0",
+            "model": "GPT-5.2",
+            "country": "us",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "submission_time": "2025-11-24T19:56:00.092865",
+            "directory_name": "GPT-5.2",
+            "release_date": "2025-12-11"
+            # Missing supports_vision - should fail
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is False
+        assert "supports_vision" in msg.lower()
 
 
 class TestScoreEntrySchema:
@@ -847,7 +880,8 @@ class TestValidateResultsDirectory:
             "tool_usage": "standard",
             "submission_time": "2025-11-24T19:56:00.092865",
             "directory_name": "GPT-5.2",
-            "release_date": "2025-12-11"
+            "release_date": "2025-12-11",
+            "supports_vision": True
         }
         scores = [{
             "benchmark": "swe-bench",


### PR DESCRIPTION
## Summary

This PR adds a `supports_vision` field to all metadata.json files to indicate whether each model supports vision/image inputs. This addresses issue #513 to help filter models for swe-bench-multimodal evaluations.

Closes #513

## Changes

1. **Validation Script** (`scripts/validate_schema.py`):
   - Added `supports_vision: bool` as a required field in the `Metadata` schema

2. **Metadata Files** (all 15 models updated):
   - Added `supports_vision` field to each model's metadata.json

3. **Tests** (`tests/test_validate_schema.py`):
   - Updated all test metadata objects to include `supports_vision`
   - Added new test `test_missing_supports_vision` to verify the field is required

## Vision Support Classification

### Models WITH Vision Support (`supports_vision: true`)

| Model | Proof |
|-------|-------|
| claude-opus-4-5 | [Anthropic Vision Documentation](https://platform.claude.com/docs/en/build-with-claude/vision) |
| claude-opus-4-6 | [Anthropic Vision Documentation](https://platform.claude.com/docs/en/build-with-claude/vision) |
| claude-sonnet-4-5 | [Claude Sonnet 4.5 Multimodality](https://www.datastudios.org/post/claude-sonnet-4-5-multimodality-vision-audio-document-understanding-and-context-integration) |
| GPT-5.2 | [OpenAI GPT-5 Page](https://openai.com/gpt-5/) - Shows "Text & vision" |
| GPT-5.2-Codex | [OpenAI GPT-5 Page](https://openai.com/gpt-5/) - Based on GPT-5.2 which supports vision |
| Gemini-3-Pro | [Google Gemini 3 Pro Vision Blog](https://blog.google/innovation-and-ai/technology/developers-tools/gemini-3-pro-vision/) |
| Gemini-3-Flash | [Google DeepMind Gemini Flash](https://deepmind.google/models/gemini/flash/) - Multimodal capabilities |
| Kimi-K2.5 | [Codecademy Kimi K2.5 Guide](https://www.codecademy.com/article/kimi-k-2-5-complete-guide-to-moonshots-ai-model) - "native multimodal integration for vision capabilities" |

### Models WITHOUT Vision Support (`supports_vision: false`)

| Model | Proof |
|-------|-------|
| DeepSeek-V3.2-Reasoner | [Fireworks AI Blog](https://fireworks.ai/blog/deepseekv3-document-inlining) - "DeepSeek v3 model... doesn't have vision capabilities" |
| GLM-4.7 | [Z.AI GLM-4.7 Documentation](https://docs.z.ai/guides/llm/glm-4.7) - Listed under LLM section, separate from VLM models (GLM-4.6V, GLM-4.5V) |
| Kimi-K2-Thinking | [Hugging Face Model Card](https://huggingface.co/moonshotai/Kimi-K2-Thinking) - Text-only model (Chat Completion, Tool Calling) |
| MiniMax-M2.1 | [Artificial Analysis Comparison](https://artificialanalysis.ai/models/comparisons/minimax-m2-1-vs-phi-4-multimodal) - "MiniMax-M2.1 does not have image input support" |
| MiniMax-M2.5 | [Artificial Analysis](https://artificialanalysis.ai/models/minimax-m2-5) - "The model supports text input, outputs text" |
| Qwen3-Coder-480B | [Ollama Qwen3-Coder](https://ollama.com/library/qwen3-coder) - Shows "Text" only, Qwen3-VL is the vision variant |
| Nemotron-3-Nano | [Artificial Analysis Comparison](https://artificialanalysis.ai/models/comparisons/nvidia-nemotron-3-nano-30b-a3b-reasoning-vs-phi-4-multimodal) - "does not have image input support" |

## Testing

- All 76 tests pass
- Validation script passes for all 30 files (15 metadata + 15 scores)

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/87777ec6b97f4effa11726ff97e22068)