### PR TITLE
Add commit0 results for claude-sonnet-4-5

### DIFF
--- a/results/claude-sonnet-4-5/scores.json
+++ b/results/claude-sonnet-4-5/scores.json
@@ -16,14 +16,15 @@
     "benchmark": "commit0",
     "score": 12.5,
     "metric": "accuracy",
-    "cost_per_instance": 2.65,
-    "average_runtime": 744.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-20864634656-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_26-01-09-21-31.tar.gz",
+    "cost_per_instance": 2.9,
+    "average_runtime": 846.0,
+    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-claude-sonnet-4-5-20250929/22098654823/results.tar.gz",
     "tags": [
       "commit0"
     ],
-    "agent_version": "v1.8.3",
-    "submission_time": "2026-01-26T16:02:48.428351+00:00"
+    "agent_version": "v1.11.0",
+    "submission_time": "2026-02-17T13:00:09+00:00",
+    "eval_visualization_page": "https://laminar.sh/shared/evals/6b5434be-df9b-4117-961c-838081a4853b"
   },
   {
     "benchmark": "gaia",


### PR DESCRIPTION
## Summary
Update commit0 benchmark results for claude-sonnet-4-5.

**Score:** 12.5%

*Automated PR from evaluation pipeline (fixed model naming)*