### PR TITLE
Add commit0 results for claude-opus-4-5

### DIFF
--- a/results/claude-opus-4-5/scores.json
+++ b/results/claude-opus-4-5/scores.json
@@ -3,14 +3,15 @@
     "benchmark": "commit0",
     "score": 37.5,
     "metric": "accuracy",
-    "cost_per_instance": 4.65,
-    "average_runtime": 495.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21324954369-claude-4-5_litellm_proxy-anthropic-claude-opus-4-5-20251101_26-01-25-03-56.tar.gz",
+    "cost_per_instance": 2.54,
+    "average_runtime": 530.0,
+    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-anthropic-claude-opus-4-5-20251101/22098667273/results.tar.gz",
     "tags": [
       "commit0"
     ],
-    "agent_version": "v1.8.3",
-    "submission_time": "2026-01-27T01:24:15.735789+00:00"
+    "agent_version": "v1.11.0",
+    "submission_time": "2026-02-17T14:39:20+00:00",
+    "eval_visualization_page": "https://laminar.sh/shared/evals/c97e4a45-8a14-428f-8eac-f77ef6eb75a8"
   },
   {
     "benchmark": "gaia",


### PR DESCRIPTION
## Summary
Update commit0 benchmark results for claude-opus-4-5.

**Score:** 37.5%

*Automated PR from evaluation pipeline (fixed model naming)*