### PR TITLE
Add commit0 results for Gemini-3-Flash

### DIFF
--- a/results/Gemini-3-Flash/scores.json
+++ b/results/Gemini-3-Flash/scores.json
@@ -3,14 +3,15 @@
     "benchmark": "commit0",
     "score": 18.8,
     "metric": "accuracy",
-    "cost_per_instance": 0.82,
-    "average_runtime": 399.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-20798907628-gemini-3-f_litellm_proxy-gemini-gemini-3-flash-preview_26-01-08-01-39.tar.gz",
+    "cost_per_instance": 1.28,
+    "average_runtime": 1524.0,
+    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-gemini-3-flash-preview/22101061866/results.tar.gz",
     "tags": [
       "commit0"
     ],
-    "agent_version": "v1.8.3",
-    "submission_time": "2026-01-26T15:53:51.936941+00:00"
+    "agent_version": "v1.11.0",
+    "submission_time": "2026-02-17T16:18:42+00:00",
+    "eval_visualization_page": "https://laminar.sh/shared/evals/6ff550c6-f901-4a49-afe8-b1750ccf2a24"
   },
   {
     "benchmark": "gaia",


### PR DESCRIPTION
## Summary
Update commit0 benchmark results for Gemini-3-Flash.

**Score:** 18.8%

*Automated PR from evaluation pipeline (fixed model naming)*