### PR TITLE
Add commit0 results for MiniMax-M2.1

### DIFF
--- a/results/MiniMax-M2.1/scores.json
+++ b/results/MiniMax-M2.1/scores.json
@@ -27,16 +27,17 @@
   },
   {
     "benchmark": "commit0",
-    "score": 25.0,
+    "score": 12.5,
     "metric": "accuracy",
-    "cost_per_instance": 0.3265,
-    "average_runtime": 826.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21219066409-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-19-53.tar.gz",
+    "cost_per_instance": 1.3,
+    "average_runtime": 2947.0,
+    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-minimax-MiniMax-M2-1/22101823247/results.tar.gz",
     "tags": [
       "commit0"
     ],
-    "agent_version": "v1.8.3",
-    "submission_time": "2026-01-26T15:55:47.616595+00:00"
+    "agent_version": "v1.11.0",
+    "submission_time": "2026-02-17T16:28:23+00:00",
+    "eval_visualization_page": "https://laminar.sh/shared/evals/1278a92b-d4ac-4402-ab42-6acd717e3947"
   },
   {
     "benchmark": "swt-bench",


### PR DESCRIPTION
## Summary
Update commit0 benchmark results for MiniMax-M2.1.

**Score:** 12.5%

*Automated PR from evaluation pipeline (fixed model naming)*