### PR TITLE
Add commit0 results for GPT-5.2-Codex

### DIFF
--- a/results/GPT-5.2-Codex/scores.json
+++ b/results/GPT-5.2-Codex/scores.json
@@ -49,16 +49,17 @@
   },
   {
     "benchmark": "commit0",
-    "score": 62.5,
+    "score": 50.0,
     "metric": "accuracy",
-    "cost_per_instance": 2.5,
-    "average_runtime": 838.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21371494522-gpt-5-2-co_litellm_proxy-gpt-5-2-codex_26-01-26-23-13.tar.gz",
+    "cost_per_instance": 2.02,
+    "average_runtime": 1079.0,
+    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-gpt-5-2-codex/22101819683/results.tar.gz",
     "tags": [
       "commit0"
     ],
-    "agent_version": "v1.8.3",
-    "submission_time": "2026-01-26T23:24:40.642068+00:00"
+    "agent_version": "v1.11.0",
+    "submission_time": "2026-02-17T15:33:52+00:00",
+    "eval_visualization_page": "https://laminar.sh/shared/evals/83fe338d-3a94-460d-af4f-82084670a423"
   },
   {
     "benchmark": "swt-bench",


### PR DESCRIPTION
## Summary
Update commit0 benchmark results for GPT-5.2-Codex.

**Score:** 50.0%

*Automated PR from evaluation pipeline (fixed model naming)*