### PR TITLE
Add commit0 results for GPT-5.2

### DIFF
--- a/results/GPT-5.2/scores.json
+++ b/results/GPT-5.2/scores.json
@@ -27,16 +27,17 @@
   },
   {
     "benchmark": "commit0",
-    "score": 18.8,
+    "score": 37.5,
     "metric": "accuracy",
-    "cost_per_instance": 0.71,
-    "average_runtime": 397.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21008947912-gpt-5-2_litellm_proxy-openai-gpt-5-2-2025-12-11_26-01-14-23-44.tar.gz",
+    "cost_per_instance": 1.34,
+    "average_runtime": 399.0,
+    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-openai-gpt-5-2-2025-12-11/22101816078/results.tar.gz",
     "tags": [
       "commit0"
     ],
-    "agent_version": "v1.8.3",
-    "submission_time": "2026-01-26T15:55:26.395894+00:00"
+    "agent_version": "v1.11.0",
+    "submission_time": "2026-02-17T14:39:30+00:00",
+    "eval_visualization_page": "https://laminar.sh/shared/evals/94cf07a1-020d-4f2e-8da7-1e2a8586dec3"
   },
   {
     "benchmark": "swt-bench",


### PR DESCRIPTION
## Summary
Update commit0 benchmark results for GPT-5.2.

**Score:** 37.5%

*Automated PR from evaluation pipeline (fixed model naming)*