### PR TITLE
Add commit0 results for Gemini-3-Pro

### DIFF
--- a/results/Gemini-3-Pro/scores.json
+++ b/results/Gemini-3-Pro/scores.json
@@ -14,16 +14,17 @@
   },
   {
     "benchmark": "commit0",
-    "score": 12.5,
+    "score": 25.0,
     "metric": "accuracy",
-    "cost_per_instance": 2.68,
-    "average_runtime": 554.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-20830419642-gemini-3-p_litellm_proxy-gemini-gemini-3-pro-preview_26-01-09-01-19.tar.gz",
+    "cost_per_instance": 3.18,
+    "average_runtime": 2239.0,
+    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-gemini-3-pro-preview/22100005487/results.tar.gz",
     "tags": [
       "commit0"
     ],
-    "agent_version": "v1.8.3",
-    "submission_time": "2026-01-26T15:55:15.726618+00:00"
+    "agent_version": "v1.11.0",
+    "submission_time": "2026-02-17T15:42:07+00:00",
+    "eval_visualization_page": "https://laminar.sh/shared/evals/bfba3513-7461-42da-9944-874848240c29"
   },
   {
     "benchmark": "gaia",


### PR DESCRIPTION
## Summary
Update commit0 benchmark results for Gemini-3-Pro.

**Score:** 25.0%

*Automated PR from evaluation pipeline (fixed model naming)*