### PR TITLE
Add commit0 results for MiniMax-M2.5

### DIFF
--- a/results/MiniMax-M2.5/scores.json
+++ b/results/MiniMax-M2.5/scores.json
@@ -1,17 +1,17 @@
 [
   {
     "benchmark": "commit0",
-    "score": 50.0,
+    "score": 18.8,
     "metric": "accuracy",
-    "cost_per_instance": 0.1627,
-    "average_runtime": 376.0,
-    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-jade-spark-2862/21897034430/results.tar.gz",
+    "cost_per_instance": 1.77,
+    "average_runtime": 1404.0,
+    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-minimax-MiniMax-M2-5/22085618521/results.tar.gz",
     "tags": [
       "commit0"
     ],
-    "agent_version": "v0.38.0",
-    "submission_time": "2026-02-11T10:21:38+00:00",
-    "eval_visualization_page": "https://laminar.sh/shared/evals/92b96069-83ec-4a5c-9319-dd35746ae198"
+    "agent_version": "v1.11.0",
+    "submission_time": "2026-02-17T05:11:59+00:00",
+    "eval_visualization_page": "https://laminar.sh/shared/evals/ca2d301f-f594-4169-8f6d-5264b98dda61"
   },
   {
     "benchmark": "gaia",


### PR DESCRIPTION
## Summary
Update commit0 benchmark results for MiniMax-M2.5.

**Score:** 18.8%

*Automated PR from evaluation pipeline (fixed model naming)*