### PR TITLE
Add commit0 results for Nemotron-3-Nano

### DIFF
--- a/results/Nemotron-3-Nano/scores.json
+++ b/results/Nemotron-3-Nano/scores.json
@@ -29,14 +29,15 @@
     "benchmark": "commit0",
     "score": 6.2,
     "metric": "accuracy",
-    "cost_per_instance": 0.13,
-    "average_runtime": 426.0,
-    "full_archive": "https://results.eval.all-hands.dev/eval-21396695574-nemotron-3_litellm_proxy-openai-NVIDIA-Nemotron-3-Nano-30B-A3B-FP8_26-01-27-12-51.tar.gz",
+    "cost_per_instance": 0.03,
+    "average_runtime": 282.0,
+    "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-openai-NVIDIA-Nemotron-3-Nano-30B-A3B-FP8/22110114668/results.tar.gz",
     "tags": [
       "commit0"
     ],
-    "agent_version": "v1.8.3",
-    "submission_time": "2026-01-27T20:00:30.624153+00:00"
+    "agent_version": "v1.11.0",
+    "submission_time": "2026-02-17T18:34:09+00:00",
+    "eval_visualization_page": "https://laminar.sh/shared/evals/c736f247-f7c5-4e63-9170-9b54a0c96229"
   },
   {
     "benchmark": "swe-bench-multimodal",


### PR DESCRIPTION
## Summary
Update commit0 benchmark results for Nemotron-3-Nano.

**Score:** 6.2%

*Automated PR from evaluation pipeline (fixed model naming)*