### PR TITLE
Fix MiniMax M2.1 and M2.5 commit0 costs with official API cache pricing

### DIFF
--- a/results/MiniMax-M2.5/scores.json
+++ b/results/MiniMax-M2.5/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "commit0",
     "score": 18.8,
     "metric": "accuracy",
-    "cost_per_instance": 1.77,
+    "cost_per_instance": 0.29,
     "average_runtime": 1404.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-minimax-MiniMax-M2-5/22085618521/results.tar.gz",
     "tags": [


### PR DESCRIPTION
## Summary
Fixes the commit0 costs for MiniMax M2.1 and M2.5 by recalculating with official MiniMax API cache pricing.

## Problem
The recorded costs were incorrect because OpenRouter's `usage.cost` field doesn't include cache discounts, even though 95%+ of tokens were cache hits.

## Fix
Recalculated using [official MiniMax API pricing](https://platform.minimax.io/docs/guides/pricing-paygo):

| Rate | Price |
|------|-------|
| Input | $0.30/M tokens |
| Output | $1.20/M tokens |
| **Cache read** | **$0.03/M tokens** (90% discount) |

## Changes

### MiniMax M2.5 commit0
- `cost_per_instance`: $1.77 → **$0.29**

| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 4,669,284 | $0.30/M | $1.40 |
| Cache hits | 87,801,819 | $0.03/M | $2.63 |
| Completion | 442,497 | $1.20/M | $0.53 |
| **Total (16 instances)** | | | **$4.57 → $0.29/instance** |

### MiniMax M2.1 commit0
- `cost_per_instance`: $1.30 → **$0.61**

| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 7,360,649 | $0.30/M | $2.21 |
| Cache hits | 162,767,501 | $0.03/M | $4.88 |
| Completion | 1,183,820 | $1.20/M | $1.42 |
| **Total (14 instances)** | | | **$8.51 → $0.61/instance** |