### PR TITLE
Fix MiniMax M2.1 commit0 cost with official API cache pricing

### DIFF
--- a/results/MiniMax-M2.1/scores.json
+++ b/results/MiniMax-M2.1/scores.json
@@ -29,7 +29,7 @@
     "benchmark": "commit0",
     "score": 12.5,
     "metric": "accuracy",
-    "cost_per_instance": 1.3,
+    "cost_per_instance": 0.61,
     "average_runtime": 2947.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-minimax-MiniMax-M2-1/22101823247/results.tar.gz",
     "tags": [


### PR DESCRIPTION
## Summary
Fixes the commit0 cost for MiniMax M2.1 by recalculating with official MiniMax API cache pricing.

Same issue as M2.5 (fixed in #653) - OpenRouter's `usage.cost` field doesn't include cache discounts.

## Fix
Recalculated using [official MiniMax API pricing](https://platform.minimax.io/docs/guides/pricing-paygo):

| Rate | Price |
|------|-------|
| Input | $0.30/M tokens |
| Output | $1.20/M tokens |
| **Cache read** | **$0.03/M tokens** (90% discount) |

## Calculation

Token usage from trajectories:
- Total prompt: 170,128,150 tokens
- Cache hits: 162,767,501 tokens (95.7%)
- Completion: 1,183,820 tokens

| Component | Tokens | Rate | Cost |
|-----------|--------|------|------|
| Non-cached input | 7,360,649 | $0.30/M | $2.21 |
| Cache hits | 162,767,501 | $0.03/M | $4.88 |
| Completion | 1,183,820 | $1.20/M | $1.42 |
| **Total** | | | **$8.51** |
| **Per instance (14)** | | | **$0.61** |

## Change
- `cost_per_instance`: $1.30 → **$0.61**

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)