### PR TITLE
Fix swt-bench full_archive URLs for GPT-5.2-Codex and Nemotron-3-Nano

### DIFF
--- a/results/GPT-5.2-Codex/scores.json
+++ b/results/GPT-5.2-Codex/scores.json
@@ -67,7 +67,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.66,
     "average_runtime": 343.0,
-    "full_archive": "https://results.eval.all-hands.dev/",
+    "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-gpt-5-2-codex/21371512858/results.tar.gz",
     "tags": [
       "swt-bench"
     ],

--- a/results/Nemotron-3-Nano/scores.json
+++ b/results/Nemotron-3-Nano/scores.json
@@ -67,7 +67,7 @@
     "metric": "accuracy",
     "cost_per_instance": 0.19,
     "average_runtime": 896.3,
-    "full_archive": "https://results.eval.all-hands.dev/",
+    "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-openai-NVIDIA-Nemotron-3-Nano-30B-A3B-FP8/21413263674/results.tar.gz",
     "tags": [
       "swt-bench"
     ],


### PR DESCRIPTION
## Summary

This PR fixes the invalid `full_archive` URLs for the swt-bench entries in GPT-5.2-Codex and Nemotron-3-Nano scores.json files.

## Changes

- Updated GPT-5.2-Codex swt-bench `full_archive` URL to: `https://results.eval.all-hands.dev/swtbench/litellm_proxy-gpt-5-2-codex/21371512858/results.tar.gz`
- Updated Nemotron-3-Nano swt-bench `full_archive` URL to: `https://results.eval.all-hands.dev/swtbench/litellm_proxy-openai-NVIDIA-Nemotron-3-Nano-30B-A3B-FP8/21413263674/results.tar.gz`

## Context

These entries previously had invalid `full_archive` URLs that were just `https://results.eval.all-hands.dev/` without an actual archive filename. The archive files have now been uploaded to the CDN and the URLs have been updated accordingly.

Fixes #662