### PR TITLE
Backfill historical recalculate-cost corrections (batch 1)

### DIFF
--- a/results/Kimi-K2.5/scores.json
+++ b/results/Kimi-K2.5/scores.json
@@ -17,7 +17,7 @@
     "benchmark": "swe-bench",
     "score": 68.8,
     "metric": "accuracy",
-    "cost_per_instance": 0.4768,
+    "cost_per_instance": 0.4063,
     "average_runtime": 707.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-moonshot-kimi-k2-5/21417485547/results.tar.gz",
     "tags": [
@@ -30,7 +30,7 @@
     "benchmark": "swt-bench",
     "score": 61.9,
     "metric": "accuracy",
-    "cost_per_instance": 0.42,
+    "cost_per_instance": 0.4246,
     "average_runtime": 385.0,
     "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-moonshot-kimi-k2-5/21535132257/results.tar.gz",
     "tags": [
@@ -43,7 +43,7 @@
     "benchmark": "gaia",
     "score": 63.6,
     "metric": "accuracy",
-    "cost_per_instance": 0.13,
+    "cost_per_instance": 1.1343,
     "average_runtime": 602.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-moonshot-kimi-k2-5/21497407856/results.tar.gz",
     "tags": [
@@ -56,7 +56,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 32.8,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 1.5773,
+    "cost_per_instance": 1.6213,
     "average_runtime": 921.0,
     "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-moonshot-kimi-k2-5/21492411890/results.tar.gz",
     "tags": [

--- a/results/Kimi-K2.5/scores.json
+++ b/results/Kimi-K2.5/scores.json
@@ -43,7 +43,7 @@
     "benchmark": "gaia",
     "score": 63.6,
     "metric": "accuracy",
-    "cost_per_instance": 1.1343,
+    "cost_per_instance": 0.3781,
     "average_runtime": 602.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-moonshot-kimi-k2-5/21497407856/results.tar.gz",
     "tags": [

--- a/results/MiniMax-M2.1/scores.json
+++ b/results/MiniMax-M2.1/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "gaia",
     "score": 40.6,
     "metric": "accuracy",
-    "cost_per_instance": 0.7413,
+    "cost_per_instance": 0.2471,
     "average_runtime": 641.0,
     "full_archive": "https://results.eval.all-hands.dev/eval-21225856759-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-23-35.tar.gz",
     "tags": [

--- a/results/MiniMax-M2.1/scores.json
+++ b/results/MiniMax-M2.1/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "gaia",
     "score": 40.6,
     "metric": "accuracy",
-    "cost_per_instance": 0.02,
+    "cost_per_instance": 0.7413,
     "average_runtime": 641.0,
     "full_archive": "https://results.eval.all-hands.dev/eval-21225856759-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-23-35.tar.gz",
     "tags": [
@@ -16,7 +16,7 @@
     "benchmark": "swe-bench",
     "score": 68.8,
     "metric": "accuracy",
-    "cost_per_instance": 0.136,
+    "cost_per_instance": 0.7118,
     "average_runtime": 579.0,
     "full_archive": "https://results.eval.all-hands.dev/eval-21213160613-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-21-21-13.tar.gz",
     "tags": [
@@ -43,7 +43,7 @@
     "benchmark": "swt-bench",
     "score": 61.4,
     "metric": "accuracy",
-    "cost_per_instance": 0.1077,
+    "cost_per_instance": 0.5441,
     "average_runtime": 473.0,
     "full_archive": "https://results.eval.all-hands.dev/eval-21226206260-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-23-09-13.tar.gz",
     "tags": [
@@ -56,7 +56,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 16.2,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 0.2118,
+    "cost_per_instance": 1.4043,
     "average_runtime": 1417.0,
     "full_archive": "https://results.eval.all-hands.dev/eval-21324690733-minimax-m2_litellm_proxy-minimax-MiniMax-M2-1_26-01-25-06-38.tar.gz",
     "tags": [

--- a/results/MiniMax-M2.5/scores.json
+++ b/results/MiniMax-M2.5/scores.json
@@ -17,7 +17,7 @@
     "benchmark": "gaia",
     "score": 47.9,
     "metric": "accuracy",
-    "cost_per_instance": 0.02,
+    "cost_per_instance": 0.0761,
     "average_runtime": 716.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-jade-spark-2862/21896759788/results.tar.gz",
     "tags": [
@@ -31,7 +31,7 @@
     "benchmark": "swe-bench",
     "score": 72.6,
     "metric": "accuracy",
-    "cost_per_instance": 0.0993,
+    "cost_per_instance": 0.2739,
     "average_runtime": 455.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-jade-spark-2862/21885618644/results.tar.gz",
     "tags": [
@@ -45,7 +45,7 @@
     "benchmark": "swt-bench",
     "score": 68.1,
     "metric": "accuracy",
-    "cost_per_instance": 0.0728,
+    "cost_per_instance": 0.2083,
     "average_runtime": 389.0,
     "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-jade-spark-2862/21870831025/results.tar.gz",
     "tags": [
@@ -59,7 +59,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 25.0,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 0.1464,
+    "cost_per_instance": 0.5028,
     "average_runtime": 611.0,
     "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-jade-spark-2862/21900356665/results.tar.gz",
     "tags": [

--- a/results/MiniMax-M2.5/scores.json
+++ b/results/MiniMax-M2.5/scores.json
@@ -17,7 +17,7 @@
     "benchmark": "gaia",
     "score": 47.9,
     "metric": "accuracy",
-    "cost_per_instance": 0.0761,
+    "cost_per_instance": 0.176,
     "average_runtime": 716.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-jade-spark-2862/21896759788/results.tar.gz",
     "tags": [
@@ -31,7 +31,7 @@
     "benchmark": "swe-bench",
     "score": 72.6,
     "metric": "accuracy",
-    "cost_per_instance": 0.2739,
+    "cost_per_instance": 0.3066,
     "average_runtime": 455.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-jade-spark-2862/21885618644/results.tar.gz",
     "tags": [
@@ -45,7 +45,7 @@
     "benchmark": "swt-bench",
     "score": 68.1,
     "metric": "accuracy",
-    "cost_per_instance": 0.2083,
+    "cost_per_instance": 0.2239,
     "average_runtime": 389.0,
     "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-jade-spark-2862/21870831025/results.tar.gz",
     "tags": [
@@ -59,7 +59,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 25.0,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 0.5028,
+    "cost_per_instance": 0.5941,
     "average_runtime": 611.0,
     "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-jade-spark-2862/21900356665/results.tar.gz",
     "tags": [

--- a/results/MiniMax-M2.5/scores.json
+++ b/results/MiniMax-M2.5/scores.json
@@ -17,7 +17,7 @@
     "benchmark": "gaia",
     "score": 47.9,
     "metric": "accuracy",
-    "cost_per_instance": 0.176,
+    "cost_per_instance": 0.0587,
     "average_runtime": 716.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-jade-spark-2862/21896759788/results.tar.gz",
     "tags": [

--- a/results/MiniMax-M2.7/scores.json
+++ b/results/MiniMax-M2.7/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 27.9,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 0.3337,
+    "cost_per_instance": 0.388,
     "average_runtime": 1084.0,
     "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-minimax-MiniMax-M2-7/23369175877/results.tar.gz",
     "tags": [
@@ -22,7 +22,7 @@
     "benchmark": "commit0",
     "score": 25.0,
     "metric": "accuracy",
-    "cost_per_instance": 0.9444,
+    "cost_per_instance": 1.1846,
     "average_runtime": 2520.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-minimax-MiniMax-M2-7/23324416020/results.tar.gz",
     "tags": [
@@ -36,7 +36,7 @@
     "benchmark": "swe-bench",
     "score": 75.6,
     "metric": "accuracy",
-    "cost_per_instance": 0.1731,
+    "cost_per_instance": 0.1795,
     "average_runtime": 529.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-minimax-MiniMax-M2-7/23463806447/results.tar.gz",
     "tags": [
@@ -50,7 +50,7 @@
     "benchmark": "gaia",
     "score": 25.5,
     "metric": "accuracy",
-    "cost_per_instance": 0.2092,
+    "cost_per_instance": 0.2163,
     "average_runtime": 676.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-minimax-MiniMax-M2-7/23855930236/results.tar.gz",
     "tags": [

--- a/results/Nemotron-3-Super/scores.json
+++ b/results/Nemotron-3-Super/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "gaia",
     "score": 40.0,
     "metric": "accuracy",
-    "cost_per_instance": 0.1138,
+    "cost_per_instance": 0.0883,
     "average_runtime": 527.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-converse-nemotron-super-3-120b/24197982616/results.tar.gz",
     "tags": [
@@ -17,7 +17,7 @@
     "benchmark": "swe-bench",
     "score": 62.0,
     "metric": "accuracy",
-    "cost_per_instance": 0.4411,
+    "cost_per_instance": 0.4663,
     "average_runtime": 874.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-converse-nemotron-super-3-120b/24135041475/results.tar.gz",
     "tags": [
@@ -31,7 +31,7 @@
     "benchmark": "swt-bench",
     "score": 45.7,
     "metric": "accuracy",
-    "cost_per_instance": 0.3162,
+    "cost_per_instance": 0.3328,
     "average_runtime": 1027.0,
     "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-converse-nemotron-super-3-120b/24106920313/results.tar.gz",
     "tags": [
@@ -45,7 +45,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 20.6,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 0.7297,
+    "cost_per_instance": 0.7679,
     "average_runtime": 1311.0,
     "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-converse-nemotron-super-3-120b/24197975725/results.tar.gz",
     "tags": [
@@ -64,7 +64,7 @@
     "benchmark": "commit0",
     "score": 12.5,
     "metric": "accuracy",
-    "cost_per_instance": 1.2252,
+    "cost_per_instance": 0.7464,
     "average_runtime": 2905.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-converse-nemotron-super-3-120b/24197990049/results.tar.gz",
     "tags": [

--- a/results/Nemotron-3-Super/scores.json
+++ b/results/Nemotron-3-Super/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "gaia",
     "score": 40.0,
     "metric": "accuracy",
-    "cost_per_instance": 0.0883,
+    "cost_per_instance": 0.1206,
     "average_runtime": 527.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-converse-nemotron-super-3-120b/24197982616/results.tar.gz",
     "tags": [
@@ -31,7 +31,7 @@
     "benchmark": "swt-bench",
     "score": 45.7,
     "metric": "accuracy",
-    "cost_per_instance": 0.3328,
+    "cost_per_instance": 0.3333,
     "average_runtime": 1027.0,
     "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-converse-nemotron-super-3-120b/24106920313/results.tar.gz",
     "tags": [
@@ -64,7 +64,7 @@
     "benchmark": "commit0",
     "score": 12.5,
     "metric": "accuracy",
-    "cost_per_instance": 0.7464,
+    "cost_per_instance": 1.2153,
     "average_runtime": 2905.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-converse-nemotron-super-3-120b/24197990049/results.tar.gz",
     "tags": [

--- a/results/Qwen3.5-Flash/scores.json
+++ b/results/Qwen3.5-Flash/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "commit0",
     "score": 12.5,
     "metric": "accuracy",
-    "cost_per_instance": 0.8625,
+    "cost_per_instance": 1.7601,
     "average_runtime": 4027.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-dashscope-qwen3-5-flash-2026-02-23/22443226509/results.tar.gz",
     "tags": [
@@ -17,7 +17,7 @@
     "benchmark": "swt-bench",
     "score": 38.3,
     "metric": "accuracy",
-    "cost_per_instance": 1.6843,
+    "cost_per_instance": 1.7107,
     "average_runtime": 3083.0,
     "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-dashscope-qwen3-5-flash-2026-02-23/24086513973/results.tar.gz",
     "tags": [
@@ -31,7 +31,7 @@
     "benchmark": "gaia",
     "score": 49.7,
     "metric": "accuracy",
-    "cost_per_instance": 0.344,
+    "cost_per_instance": 0.2159,
     "average_runtime": 847.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-dashscope-qwen3-5-flash-2026-02-23/24193141939/results.tar.gz",
     "tags": [
@@ -45,7 +45,7 @@
     "benchmark": "swe-bench",
     "score": 62.0,
     "metric": "accuracy",
-    "cost_per_instance": 2.1457,
+    "cost_per_instance": 2.0561,
     "average_runtime": 4132.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-dashscope-qwen3-5-flash-2026-02-23/24193134639/results.tar.gz",
     "tags": [

--- a/results/Qwen3.5-Flash/scores.json
+++ b/results/Qwen3.5-Flash/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "commit0",
     "score": 12.5,
     "metric": "accuracy",
-    "cost_per_instance": 1.7601,
+    "cost_per_instance": 4.3309,
     "average_runtime": 4027.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-dashscope-qwen3-5-flash-2026-02-23/22443226509/results.tar.gz",
     "tags": [
@@ -31,7 +31,7 @@
     "benchmark": "gaia",
     "score": 49.7,
     "metric": "accuracy",
-    "cost_per_instance": 0.2159,
+    "cost_per_instance": 0.3422,
     "average_runtime": 847.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-dashscope-qwen3-5-flash-2026-02-23/24193141939/results.tar.gz",
     "tags": [
@@ -45,7 +45,7 @@
     "benchmark": "swe-bench",
     "score": 62.0,
     "metric": "accuracy",
-    "cost_per_instance": 2.0561,
+    "cost_per_instance": 2.1639,
     "average_runtime": 4132.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-dashscope-qwen3-5-flash-2026-02-23/24193134639/results.tar.gz",
     "tags": [

--- a/results/Qwen3.6-Plus/scores.json
+++ b/results/Qwen3.6-Plus/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "gaia",
     "score": 72.1,
     "metric": "accuracy",
-    "cost_per_instance": 0.2924,
+    "cost_per_instance": 0.3377,
     "average_runtime": 308.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-dashscope-qwen3-6-plus/24043637505/results.tar.gz",
     "tags": [
@@ -17,7 +17,7 @@
     "benchmark": "swt-bench",
     "score": 62.1,
     "metric": "accuracy",
-    "cost_per_instance": 2.081,
+    "cost_per_instance": 2.085,
     "average_runtime": 851.0,
     "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-dashscope-qwen3-6-plus/24043642717/results.tar.gz",
     "tags": [
@@ -59,7 +59,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 30.9,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 2.2661,
+    "cost_per_instance": 2.3158,
     "average_runtime": 638.0,
     "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-dashscope-qwen3-6-plus/23949324373/results.tar.gz",
     "tags": [

--- a/results/Qwen3.6-Plus/scores.json
+++ b/results/Qwen3.6-Plus/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "gaia",
     "score": 72.1,
     "metric": "accuracy",
-    "cost_per_instance": 0.3398,
+    "cost_per_instance": 0.2924,
     "average_runtime": 308.0,
     "full_archive": "https://results.eval.all-hands.dev/gaia/litellm_proxy-dashscope-qwen3-6-plus/24043637505/results.tar.gz",
     "tags": [
@@ -17,7 +17,7 @@
     "benchmark": "swt-bench",
     "score": 62.1,
     "metric": "accuracy",
-    "cost_per_instance": 2.0405,
+    "cost_per_instance": 2.081,
     "average_runtime": 851.0,
     "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-dashscope-qwen3-6-plus/24043642717/results.tar.gz",
     "tags": [
@@ -31,7 +31,7 @@
     "benchmark": "swe-bench",
     "score": 74.2,
     "metric": "accuracy",
-    "cost_per_instance": 1.5243,
+    "cost_per_instance": 1.5379,
     "average_runtime": 664.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-dashscope-qwen3-6-plus/23957434539/results.tar.gz",
     "tags": [
@@ -45,7 +45,7 @@
     "benchmark": "commit0",
     "score": 50.0,
     "metric": "accuracy",
-    "cost_per_instance": 4.4049,
+    "cost_per_instance": 4.4184,
     "average_runtime": 1635.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-dashscope-qwen3-6-plus/23957367199/results.tar.gz",
     "tags": [
@@ -59,7 +59,7 @@
     "benchmark": "swe-bench-multimodal",
     "score": 30.9,
     "metric": "solveable_accuracy",
-    "cost_per_instance": 2.2662,
+    "cost_per_instance": 2.2661,
     "average_runtime": 638.0,
     "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-dashscope-qwen3-6-plus/23949324373/results.tar.gz",
     "tags": [


### PR DESCRIPTION
## Summary
Resolves #909.

This draft backfills score-file corrections for historical `Recalculate Costs` runs from `OpenHands/evaluation`. I used the **GitHub Actions history as the source of truth**, then recomputed each affected archive locally with the latest logic from OpenHands/evaluation#525 plus the follow-up hybrid accounting change on top of that branch.

### Included in this PR
- archive-URL workflow history with current scoreboard impact:
  - `Qwen3.5-Flash`
  - `Nemotron-3-Super`
  - `Qwen3.6-Plus`
  - `MiniMax-M2.7`
  - `MiniMax-M2.5` (the historical `jade-spark-2862` action-run archives)
- legacy PR-targeted workflow history whose corrected archives still map to current score entries:
  - `MiniMax-M2.1`
  - `Kimi-K2.5`

At this point, the PR covers the historical recalculate-cost runs that still have **current scoreboard impact** in `results/*/scores.json`.

## Key findings from the audit
- audited **154** historical `Recalculate Costs` workflow runs in `OpenHands/evaluation`
  - **149** success
  - **4** failure
  - **1** cancelled
- normalized them into:
  - **38** unique archive-targeted runs
  - **25** unique PR-targeted runs
  - **3** noncanonical/manual workflow-development runs
- classified the PR-targeted history into:
  - **14 merged** PR targets
  - **11 closed/unmerged** PR targets

## Why these changes are needed
The historical recalculate-costs job had two gaps:
1. it could miss paid retry / critic-attempt spend recorded in `output.critic_attempt_*.jsonl`
2. on some crashed or failed instances, the benchmark output rows had missing `metrics`, while the captured conversation `base_state.json` still contained real token usage

These backfills now use a **hybrid ledger**:
- prefer `output.critic_attempt_*.jsonl`, then `output.jsonl`
- supplement only the JSONL rows with missing metrics from `conversations/*/base_state.json`
- fall back entirely to conversation archives only when no output JSONLs exist

That means some previously “corrected” costs go **up** under this PR: they were still undercounting failed-run spend that never made it into the final output rows.

## Notable Qwen3.5-Flash conclusion
The large `Qwen3.5-Flash` `commit0` jump is real, but it is **primarily a historical pricing bug**, not a critic-pass artifact.

The old historical recalculate run used manual prices:
- input miss = `0.1`
- cache hit = `0.1`
- output = `0.4`

But `results/Qwen3.5-Flash/metadata.json` specifies:
- input miss = `0.5`
- cache hit = `0.1`
- output = `2.5`

Recomputing the same archive with the old manual prices reproduces the previous stored value almost exactly (`0.8625`), while recomputing with metadata pricing yields the corrected value (`4.3309`). The critic/hybrid logic only makes a small secondary adjustment on top of that.

## Remaining historical runs after this PR
The remaining unmatched historical workflow runs appear to have **no current scoreboard impact**. They fall into three buckets:
- superseded archive reruns that were later overwritten by newer canonical archives
- closed/unmerged PR-targeted runs
- workflow-development/manual runs:
  - `PR add-cost-summary-to-recalculate-action`
  - `Qwen3.5-Flash (miss=0.1, hit=0.1, out=0.4)`
  - `eval/MiniMax-M2.7/swt-bench-20260323-215850`

## Related work
- hybrid recalculation accounting: `OpenHands/evaluation#525`
- producer-side preservation of failure metrics/costs: `OpenHands/benchmarks#694`

_This PR was created by an AI assistant (OpenHands) on behalf of the user._
