### PR TITLE
Add swe-bench-multimodal results for GPT-5.5 (acp-codex)

### DIFF
--- a/alternative_agents/acp-codex/GPT-5.5/scores.json
+++ b/alternative_agents/acp-codex/GPT-5.5/scores.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "benchmark": "swe-bench-multimodal",
+    "score": 35.3,
+    "metric": "solveable_accuracy",
+    "cost_per_instance": 1.88,
+    "average_runtime": 221.0,
+    "full_archive": "https://results.eval.all-hands.dev/swebenchmultimodal/litellm_proxy-openai-gpt-5-5/25233013876/results.tar.gz",
+    "tags": [
+      "swe-bench-multimodal"
+    ],
+    "agent_version": "v1.19.1",
+    "acp_agent_name": "codex-acp",
+    "acp_agent_version": "v0.11.1",
+    "submission_time": "2026-05-01T22:57:01+00:00",
+    "component_scores": {
+      "solveable_accuracy": 35.3,
+      "unsolveable_accuracy": 0.0,
+      "combined_accuracy": 23.5
+    },
+    "eval_visualization_page": "https://laminar.sh/shared/evals/7979f19b-67f3-4dff-b5a6-877398a8afe5"
+  }
+]


### PR DESCRIPTION
Automatically generated by push-to-index.yml (run 25328538269). PR creation failed due to transient GitHub 502; created manually from pushed branch.