### PR TITLE
Restart HF Space when complete-models.json changes on main

### DIFF
--- a/.github/workflows/restart-hf-space.yml
+++ b/.github/workflows/restart-hf-space.yml
@@ -1,0 +1,27 @@
+name: Restart HF Space
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'complete-models.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  restart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restart Hugging Face Space
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "::error::HF_TOKEN secret is not set. Add a Hugging Face token with write access to the OpenHands/openhands-index Space."
+            exit 1
+          fi
+          curl -sS -f -X POST \
+            -H "Authorization: Bearer $HF_TOKEN" \
+            "https://huggingface.co/api/spaces/OpenHands/openhands-index/restart"

--- a/.github/workflows/restart-hf-space.yml
+++ b/.github/workflows/restart-hf-space.yml
@@ -23,5 +23,5 @@ jobs:
             exit 1
           fi
           curl -sS -f -X POST \
-            -H "Authorization: Bearer $HF_TOKEN" \
+            -H "Authorization: Bearer $HF_REPO_TOKEN" \
             "https://huggingface.co/api/spaces/OpenHands/openhands-index/restart"

--- a/.github/workflows/restart-hf-space.yml
+++ b/.github/workflows/restart-hf-space.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          if [ -z "$HF_TOKEN" ]; then
+          if [ -z "$HF_REPO_TOKEN" ]; then
             echo "::error::HF_TOKEN secret is not set. Add a Hugging Face token with write access to the OpenHands/openhands-index Space."
             exit 1
           fi

--- a/.github/workflows/restart-hf-space.yml
+++ b/.github/workflows/restart-hf-space.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Restart Hugging Face Space
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO_TOKEN: ${{ secrets.HF_REPO_TOKEN }}
         run: |
           if [ -z "$HF_REPO_TOKEN" ]; then
-            echo "::error::HF_TOKEN secret is not set. Add a Hugging Face token with write access to the OpenHands/openhands-index Space."
+            echo "::error::HF_REPO_TOKEN secret is not set. Add a Hugging Face token with write access to the OpenHands/openhands-index Space."
             exit 1
           fi
           curl -sS -f -X POST \


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow (`.github/workflows/restart-hf-space.yml`) that restarts the [`OpenHands/openhands-index`](https://huggingface.co/spaces/OpenHands/openhands-index) Hugging Face Space whenever `complete-models.json` changes on `main`, so the Space always shows the latest benchmark results.

Fixes #1113.

## How it works

- **Trigger:** `push` to `main` filtered by `paths: ['complete-models.json']`, plus `workflow_dispatch` so maintainers can also restart the Space manually from the Actions tab.
- **Action:** A single step that calls `POST https://huggingface.co/api/spaces/OpenHands/openhands-index/restart` with a `Bearer $HF_REPO_TOKEN` header (the same endpoint that `huggingface_hub.HfApi.restart_space` calls). `curl -f` makes the step fail loudly on any 4xx/5xx response.
- **Permissions:** Only `contents: read` — no third-party actions are used, keeping the supply‑chain surface minimal.

## ⚠️ Required before this can run: add HF_REPO_TOKEN` secret

Before merging (or shortly after), please add a repository secret named **`HF_REPO_TOKEN`** under `Settings → Secrets and variables → Actions`:

- Token type: a Hugging Face **fine-grained access token** is recommended.
- Minimum scope: **write** access to the `OpenHands/openhands-index` Space only (no other scopes needed — we just call the restart endpoint).
- Recommendation: create it under an org-owned bot/service account rather than a personal one, set an expiry, and document the rotation. If the secret is missing, the workflow exits with a clear `::error::` message rather than silently no-op'ing.

If you'd prefer a different secret name (e.g. `HUGGINGFACE_TOKEN`), just say the word and I'll update the workflow.

## Notes

- The existing `update-complete-models.yml` workflow opens a PR with regenerated `complete-models.json`; once a maintainer merges that PR, the resulting push to `main` fires this new workflow and the Space restarts. (Pushes made with the default `GITHUB_TOKEN` do not trigger downstream workflows, but a human-performed merge does — so the chain works.)
- If we ever want to bust the build cache instead of just restarting the runtime, swap `/restart` for `/restart-factory` in the workflow.
- No application code changed, so no tests were added (workflow file only).

---
_This PR was opened by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b7de1781-1d60-4a4c-9b08-517e33a0b516)