### PR TITLE
Update DeepSeek-V4-Pro pricing to reflect permanent discounted rates

### DIFF
--- a/results/DeepSeek-V4-Pro/metadata.json
+++ b/results/DeepSeek-V4-Pro/metadata.json
@@ -10,8 +10,8 @@
   "parameter_count_b": 1600,
   "active_parameter_count_b": 49,
   "supports_vision": false,
-  "input_price": 1.74,
-  "output_price": 3.48,
-  "cache_read_price": 0.0145,
+  "input_price": 0.435,
+  "output_price": 0.87,
+  "cache_read_price": 0.003625,
   "cache_write_price": null
 }

--- a/results/DeepSeek-V4-Pro/scores.json
+++ b/results/DeepSeek-V4-Pro/scores.json
@@ -3,7 +3,7 @@
     "benchmark": "swt-bench",
     "score": 68.1,
     "metric": "accuracy",
-    "cost_per_instance": 0.1417,
+    "cost_per_instance": 0.0354,
     "average_runtime": 589.0,
     "full_archive": "https://results.eval.all-hands.dev/swtbench/litellm_proxy-deepseek-deepseek-v4-pro/25967349971/results.tar.gz",
     "tags": [
@@ -17,7 +17,7 @@
     "benchmark": "swe-bench",
     "score": 73.2,
     "metric": "accuracy",
-    "cost_per_instance": 0.1579,
+    "cost_per_instance": 0.0395,
     "average_runtime": 751.0,
     "full_archive": "https://results.eval.all-hands.dev/swebench/litellm_proxy-deepseek-deepseek-v4-pro/25967325971/results.tar.gz",
     "tags": [
@@ -31,7 +31,7 @@
     "benchmark": "commit0",
     "score": 12.5,
     "metric": "accuracy",
-    "cost_per_instance": 0.6306,
+    "cost_per_instance": 0.1577,
     "average_runtime": 1805.0,
     "full_archive": "https://results.eval.all-hands.dev/commit0/litellm_proxy-deepseek-deepseek-v4-pro/25976440104/results.tar.gz",
     "tags": [

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -280,11 +280,11 @@ class TestMetadataSchema:
             "directory_name": "DeepSeek-V4-Pro",
             "release_date": "2026-04-24",
             "supports_vision": False,
-            "input_price": 1.74,
-            "output_price": 3.48,
+            "input_price": 0.435,
+            "output_price": 0.87,
             "parameter_count_b": 1600,
             "active_parameter_count_b": 49,
-            "cache_read_price": 0.0145,
+            "cache_read_price": 0.003625,
             "cache_write_price": None
         }
         metadata_file = tmp_path / "metadata.json"


### PR DESCRIPTION
## Summary

Updates DeepSeek-V4-Pro pricing to reflect the permanent discounted rates, as announced by DeepSeek. Per [pricing footnote #3](https://api-docs.deepseek.com/quick_start/pricing):

> The deepseek-v4-pro model API pricing will be officially adjusted to 1/4 of the original price after the 75% discount promotion ends on 2026/05/31 15:59 UTC.

The discounted prices (75% off) will become the permanent prices going forward.

## Changes

### `results/DeepSeek-V4-Pro/metadata.json`
Updated per-token prices (1/4 of original):
- `input_price`: $1.74 → $0.435 per 1M tokens
- `output_price`: $3.48 → $0.87 per 1M tokens
- `cache_read_price`: $0.0145 → $0.003625 per 1M tokens

### `results/DeepSeek-V4-Pro/scores.json`
Updated `cost_per_instance` proportionally:
- swt-bench: $0.1417 → $0.0354
- swe-bench: $0.1579 → $0.0395
- commit0: $0.6306 → $0.1577

### `tests/test_validate_schema.py`
Updated the DeepSeek-V4-Pro test metadata to use the new prices.

## Testing

- All 144 existing tests pass
- Schema validation passes for all files

Fixes #1137

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5ef0bea4-4be0-4e90-b618-51a640dd386e)