### PR TITLE
Add GitHub Action to publish leaderboard to HF Dataset

### DIFF
--- a/.github/workflows/publish-hf-dataset.yml
+++ b/.github/workflows/publish-hf-dataset.yml
@@ -37,6 +37,9 @@ jobs:
 
       - name: Build and publish dataset
         env:
+          # HF_DATASET_TOKEN is the *repo secret* (fine-grained, write-scoped
+          # to the OpenHands/openhands-index dataset only). The script reads
+          # the standard HF_TOKEN env name so it can also be run locally.
           HF_TOKEN: ${{ secrets.HF_DATASET_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}
           FORCE: ${{ github.event.inputs.force }}

--- a/.github/workflows/publish-hf-dataset.yml
+++ b/.github/workflows/publish-hf-dataset.yml
@@ -23,9 +23,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+    publish:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-hf-dataset.yml
+++ b/.github/workflows/publish-hf-dataset.yml
@@ -1,0 +1,43 @@
+name: Publish HF Dataset
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'results/**'
+      - 'alternative_agents/**'
+      - 'scripts/publish_hf_dataset.py'
+      - '.github/workflows/publish-hf-dataset.yml'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Push even if content hash matches remote'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-hf-dataset
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install "huggingface_hub>=0.30" "pandas>=2.0" "pyarrow>=15" tabulate
+
+      - name: Build and publish dataset
+        env:
+          HF_TOKEN: ${{ secrets.HF_DATASET_TOKEN }}
+          GITHUB_SHA: ${{ github.sha }}
+          FORCE: ${{ github.event.inputs.force }}
+        run: python scripts/publish_hf_dataset.py

--- a/.github/workflows/publish-hf-dataset.yml
+++ b/.github/workflows/publish-hf-dataset.yml
@@ -23,7 +23,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-hf-dataset.yml
+++ b/.github/workflows/publish-hf-dataset.yml
@@ -31,9 +31,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'scripts/requirements-publish.txt'
 
       - name: Install dependencies
-        run: pip install "huggingface_hub>=0.30" "pandas>=2.0" "pyarrow>=15" tabulate
+        run: pip install -r scripts/requirements-publish.txt
 
       - name: Build and publish dataset
         env:

--- a/.github/workflows/publish-hf-dataset.yml
+++ b/.github/workflows/publish-hf-dataset.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-    publish:
+  publish:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -162,7 +162,7 @@ def build_dataframe() -> pd.DataFrame:
 
 
 def content_hash(df: pd.DataFrame) -> str:
-    payload = df.reindex(sorted(df.columns), axis=1).to_csv(index=False).encode("utf-8")
+    payload = df.reindex(sorted(df.columns), axis=1).to_csv(index=False, float_format="%.10g").encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
 
 

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -110,7 +110,6 @@ def _flatten(model_dir: Path, agent_label: str) -> dict[str, Any] | None:
 
     completed = [bench_scores[b] for b in BENCHMARKS if b in bench_scores and bench_scores[b]["score"] is not None]
     if not completed:
-    if not completed:
         logger.info(
             "Skipping %s (%s): no completed benchmarks with non-null scores.",
             model_dir.name,

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -191,7 +191,7 @@ def resolve_source_version() -> tuple[str, str, str, datetime]:
     short = sha[:7]
     iso = _git("show", "-s", "--format=%cI", sha)
     dt = datetime.fromisoformat(iso).astimezone(timezone.utc)
-    version = f"{dt.year}.{dt.month}.{dt.day}-{short}"
+    version = f"{dt.year}.{dt.month:02d}.{dt.day:02d}-{short}"
     return sha, short, version, dt
 
 

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 import pandas as pd
+import tabulate  # noqa: F401  # required by DataFrame.to_markdown(); fail loudly at startup if missing
 from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
 from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
 
@@ -172,8 +173,8 @@ def get_remote_hash(api: HfApi) -> str | None:
         return None
 
 
-def resolve_source_version() -> tuple[str, str, datetime]:
-    """Return (short_sha, version_string, commit_datetime_utc).
+def resolve_source_version() -> tuple[str, str, str, datetime]:
+    """Return (full_sha, short_sha, version_string, commit_datetime_utc).
 
     version_string = "YYYY.M.D-<short_sha>" (e.g. 2026.5.29-4c92417).
     Date comes from the source commit's committer date so the version
@@ -181,12 +182,10 @@ def resolve_source_version() -> tuple[str, str, datetime]:
     """
     sha = os.environ.get("GITHUB_SHA") or _git("rev-parse", "HEAD")
     short = sha[:7]
-    iso = os.environ.get("GITHUB_COMMIT_DATE") or _git(
-        "show", "-s", "--format=%cI", sha
-    )
+    iso = _git("show", "-s", "--format=%cI", sha)
     dt = datetime.fromisoformat(iso).astimezone(timezone.utc)
     version = f"{dt.year}.{dt.month}.{dt.day}-{short}"
-    return short, version, dt
+    return sha, short, version, dt
 
 
 def _git(*args: str) -> str:
@@ -294,8 +293,7 @@ def main() -> int:
         logger.error("create_repo failed: %s", e)
         return 1
 
-    short_sha, version, _ = resolve_source_version()
-    source_sha = os.environ.get("GITHUB_SHA") or _git("rev-parse", "HEAD")
+    source_sha, _, version, _ = resolve_source_version()
     generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
     buf = io.BytesIO()

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -334,7 +334,7 @@ def main() -> int:
         return 1
     logger.info("Published %d rows to %s as v%s", len(df), DATASET_REPO, version)
 
-    # Immutable tag so users can pin: load_dataset(..., revision="v2026.5.29-4c92417")
+    # Immutable tag so users can pin: load_dataset(..., revision="v2026.05.29-4c92417")
     tag = f"v{version}"
     try:
         api.create_tag(

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Build a flat leaderboard table from results/ and alternative_agents/, then
+publish it to the HF Dataset repo `OpenHands/openhands-index` so consumers
+can do:
+
+    from datasets import load_dataset
+    ds = load_dataset("OpenHands/openhands-index", split="test")
+
+Run from CI on every push to main. Requires HF_TOKEN env var (fine-grained
+token, write-scoped to OpenHands/openhands-index dataset only).
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+from huggingface_hub import HfApi, hf_hub_download
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
+
+logger = logging.getLogger("publish_hf_dataset")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATASET_REPO = os.environ.get("DATASET_REPO", "OpenHands/openhands-index")
+PARQUET_PATH = "test.parquet"
+README_PATH = "README.md"
+HASH_PATH = ".source_hash"  # stored in the dataset to detect no-op runs
+
+BENCHMARK_TO_CATEGORY = {
+    "swe-bench": "Issue Resolution",
+    "swe-bench-multimodal": "Frontend",
+    "commit0": "Greenfield",
+    "swt-bench": "Testing",
+    "gaia": "Information Gathering",
+}
+CATEGORIES = list(BENCHMARK_TO_CATEGORY.values())
+BENCHMARKS = list(BENCHMARK_TO_CATEGORY.keys())
+
+
+def _iter_model_dirs() -> Iterable[tuple[Path, str]]:
+    """Yield (model_dir, agent_label) pairs from results/ and alternative_agents/."""
+    results_dir = REPO_ROOT / "results"
+    if results_dir.is_dir():
+        for d in sorted(results_dir.iterdir()):
+            if d.is_dir() and (d / "metadata.json").exists():
+                yield d, "OpenHands"
+
+    alt_root = REPO_ROOT / "alternative_agents"
+    if alt_root.is_dir():
+        for agent_type_dir in sorted(alt_root.iterdir()):
+            if not agent_type_dir.is_dir():
+                continue
+            for d in sorted(agent_type_dir.iterdir()):
+                if d.is_dir() and (d / "metadata.json").exists():
+                    yield d, agent_type_dir.name
+
+
+def _load_json(path: Path) -> Any:
+    with path.open() as f:
+        return json.load(f)
+
+
+def _flatten(model_dir: Path, agent_label: str) -> dict[str, Any] | None:
+    """Build one row from a model directory. Returns None if the dir is invalid."""
+    try:
+        meta = _load_json(model_dir / "metadata.json")
+        scores = _load_json(model_dir / "scores.json")
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        logger.warning("Skipping %s: %s", model_dir, e)
+        return None
+
+    by_bench = {entry["benchmark"]: entry for entry in scores if "benchmark" in entry}
+
+    bench_scores: dict[str, dict[str, Any]] = {}
+    for b in BENCHMARKS:
+        if b in by_bench:
+            e = by_bench[b]
+            bench_scores[b] = {
+                "score": e.get("score"),
+                "cost": e.get("cost_per_instance"),
+                "runtime": e.get("average_runtime"),
+                "logs_url": e.get("full_archive"),
+                "visualization_url": e.get("eval_visualization_page"),
+            }
+
+    completed = [bench_scores[b] for b in BENCHMARKS if b in bench_scores and bench_scores[b]["score"] is not None]
+    if not completed:
+        return None
+
+    def _mean(key: str) -> float | None:
+        vals = [c[key] for c in completed if c.get(key) is not None]
+        return round(sum(vals) / len(vals), 4) if vals else None
+
+    row: dict[str, Any] = {
+        "id": f"{agent_label}_{meta.get('agent_version', '')}_{meta.get('model', model_dir.name)}",
+        "agent_name": meta.get("agent_name", agent_label),
+        "agent_type": agent_label,
+        "language_model": meta.get("model", model_dir.name),
+        "sdk_version": meta.get("agent_version"),
+        "openness": meta.get("openness"),
+        "country": meta.get("country"),
+        "supports_vision": meta.get("supports_vision"),
+        "release_date": meta.get("release_date"),
+        "average_score": _mean("score"),
+        "average_cost": _mean("cost"),
+        "average_runtime": _mean("runtime"),
+        "categories_completed": len(completed),
+    }
+
+    for b in BENCHMARKS:
+        cat_slug = BENCHMARK_TO_CATEGORY[b].lower().replace(" ", "_")
+        bs = bench_scores.get(b, {})
+        row[f"{cat_slug}_score"] = bs.get("score")
+        row[f"{cat_slug}_cost"] = bs.get("cost")
+        row[f"{cat_slug}_runtime"] = bs.get("runtime")
+        row[f"{cat_slug}_logs_url"] = bs.get("logs_url")
+        row[f"{cat_slug}_visualization_url"] = bs.get("visualization_url")
+
+    return row
+
+
+def build_dataframe() -> pd.DataFrame:
+    rows = [r for d, label in _iter_model_dirs() if (r := _flatten(d, label)) is not None]
+    if not rows:
+        raise RuntimeError("No model rows found; refusing to publish empty dataset.")
+    df = pd.DataFrame(rows)
+    df = df.sort_values("average_score", ascending=False, na_position="last").reset_index(drop=True)
+    return df
+
+
+def content_hash(df: pd.DataFrame) -> str:
+    payload = df.reindex(sorted(df.columns), axis=1).to_csv(index=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def get_remote_hash(api: HfApi) -> str | None:
+    try:
+        path = hf_hub_download(
+            repo_id=DATASET_REPO, repo_type="dataset", filename=HASH_PATH,
+            token=api.token,
+        )
+        return Path(path).read_text().strip()
+    except (EntryNotFoundError, HfHubHTTPError):
+        return None
+
+
+def dataset_card(df: pd.DataFrame, generated_at: str, source_sha: str | None) -> str:
+    top = df[["language_model", "sdk_version", "agent_name", "average_score",
+              "categories_completed", "release_date"]].head(15)
+    top_md = top.to_markdown(index=False, floatfmt=".2f") if not top.empty else "_(empty)_"
+    src = f"`{source_sha[:8]}`" if source_sha else "_unknown_"
+    return f"""---
+license: apache-2.0
+pretty_name: OpenHands Index Leaderboard
+tags:
+- leaderboard
+- code
+- agents
+- benchmark
+configs:
+- config_name: default
+  data_files:
+  - split: test
+    path: test.parquet
+---
+
+# OpenHands Index — Leaderboard Snapshot
+
+Auto-published from <https://github.com/OpenHands/openhands-index-results>
+on every push to `main`. Matches the table shown at the
+[OpenHands Index Space](https://huggingface.co/spaces/OpenHands/openhands-index).
+
+```python
+from datasets import load_dataset
+ds = load_dataset("{DATASET_REPO}", split="test")
+df = ds.to_pandas()
+```
+
+## Categories
+
+| Category | Backing benchmark |
+|---|---|
+| Issue Resolution | SWE-Bench |
+| Frontend | SWE-Bench Multimodal |
+| Greenfield | Commit0 |
+| Testing | SWT-Bench |
+| Information Gathering | GAIA |
+
+`average_score` is the mean of the per-benchmark scores actually completed.
+`categories_completed` tells you how many benchmarks the model has run.
+
+## Snapshot
+
+- Rows: **{len(df)}**
+- Generated: `{generated_at}`
+- Source commit: {src}
+
+## Top 15 by average score
+
+{top_md}
+"""
+
+
+def main() -> int:
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        logger.error("HF_TOKEN env var not set.")
+        return 2
+
+    api = HfApi(token=token)
+    df = build_dataframe()
+    new_hash = content_hash(df)
+    logger.info("Built %d rows; content hash %s", len(df), new_hash[:12])
+
+    remote_hash = get_remote_hash(api)
+    force = os.environ.get("FORCE", "").lower() in {"1", "true", "yes"}
+    if not force and remote_hash == new_hash:
+        logger.info("Dataset already up-to-date (remote hash matches). Skipping push.")
+        return 0
+
+    try:
+        api.create_repo(DATASET_REPO, repo_type="dataset", exist_ok=True, private=False)
+    except HfHubHTTPError as e:
+        logger.error("create_repo failed: %s", e)
+        return 1
+
+    buf = io.BytesIO()
+    df.to_parquet(buf, index=False)
+    parquet_bytes = buf.getvalue()
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    source_sha = os.environ.get("GITHUB_SHA")
+    readme_bytes = dataset_card(df, generated_at, source_sha).encode("utf-8")
+
+    from huggingface_hub import CommitOperationAdd
+    ops = [
+        CommitOperationAdd(path_in_repo=PARQUET_PATH, path_or_fileobj=parquet_bytes),
+        CommitOperationAdd(path_in_repo=README_PATH, path_or_fileobj=readme_bytes),
+        CommitOperationAdd(path_in_repo=HASH_PATH, path_or_fileobj=new_hash.encode()),
+    ]
+    short_sha = (source_sha or "")[:7]
+    msg = f"Update leaderboard: {len(df)} models" + (f" (source {short_sha})" if short_sha else "")
+    api.create_commit(
+        repo_id=DATASET_REPO, repo_type="dataset",
+        operations=ops, commit_message=msg,
+    )
+    logger.info("Published %d rows to %s", len(df), DATASET_REPO)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -87,7 +87,14 @@ def _flatten(model_dir: Path, agent_label: str) -> dict[str, Any] | None:
         logger.warning("Skipping %s: %s", model_dir, e)
         return None
 
-    by_bench = {entry["benchmark"]: entry for entry in scores if "benchmark" in entry}
+    by_bench: dict[str, Any] = {}
+    for entry in scores:
+        b = entry.get("benchmark")
+        if not b:
+            continue
+        if b in by_bench:
+            logger.warning("Duplicate benchmark %r in %s/scores.json; keeping last.", b, model_dir.name)
+        by_bench[b] = entry
 
     bench_scores: dict[str, dict[str, Any]] = {}
     for b in BENCHMARKS:
@@ -293,7 +300,11 @@ def main() -> int:
         logger.error("create_repo failed: %s", e)
         return 1
 
-    source_sha, _, version, _ = resolve_source_version()
+    try:
+        source_sha, _, version, _ = resolve_source_version()
+    except subprocess.CalledProcessError as e:
+        logger.error("Failed to resolve source version: %s", e)
+        return 1
     generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
     buf = io.BytesIO()

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -183,7 +183,7 @@ def get_remote_hash(api: HfApi) -> str | None:
 def resolve_source_version() -> tuple[str, str, str, datetime]:
     """Return (full_sha, short_sha, version_string, commit_datetime_utc).
 
-    version_string = "YYYY.M.D-<short_sha>" (e.g. 2026.5.29-4c92417).
+    version_string = "YYYY.MM.DD-<short_sha>" (e.g. 2026.05.29-4c92417).
     Date comes from the source commit's committer date so the version
     reflects when the data was finalized, not when CI happened to run.
     """

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -110,6 +110,12 @@ def _flatten(model_dir: Path, agent_label: str) -> dict[str, Any] | None:
 
     completed = [bench_scores[b] for b in BENCHMARKS if b in bench_scores and bench_scores[b]["score"] is not None]
     if not completed:
+    if not completed:
+        logger.info(
+            "Skipping %s (%s): no completed benchmarks with non-null scores.",
+            model_dir.name,
+            agent_label,
+        )
         return None
 
     def _mean(key: str) -> float | None:

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -17,13 +17,14 @@ import io
 import json
 import logging
 import os
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
 import pandas as pd
-from huggingface_hub import HfApi, hf_hub_download
+from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
 from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
 
 logger = logging.getLogger("publish_hf_dataset")
@@ -42,12 +43,19 @@ BENCHMARK_TO_CATEGORY = {
     "swt-bench": "Testing",
     "gaia": "Information Gathering",
 }
-CATEGORIES = list(BENCHMARK_TO_CATEGORY.values())
 BENCHMARKS = list(BENCHMARK_TO_CATEGORY.keys())
 
 
 def _iter_model_dirs() -> Iterable[tuple[Path, str]]:
-    """Yield (model_dir, agent_label) pairs from results/ and alternative_agents/."""
+    """Yield (model_dir, agent_label) pairs from results/ and alternative_agents/.
+
+    Layouts handled:
+      results/<model>/{metadata.json,scores.json}          -> agent_label="OpenHands"
+      alternative_agents/<agent_type>/<model>/{...}        -> agent_label="<agent_type>"
+
+    Anything nested deeper than that is ignored; if the layout changes,
+    extend this function rather than the call sites.
+    """
     results_dir = REPO_ROOT / "results"
     if results_dir.is_dir():
         for d in sorted(results_dir.iterdir()):
@@ -100,8 +108,11 @@ def _flatten(model_dir: Path, agent_label: str) -> dict[str, Any] | None:
         vals = [c[key] for c in completed if c.get(key) is not None]
         return round(sum(vals) / len(vals), 4) if vals else None
 
+    # `id` mirrors the on-disk path, which the repo already treats as unique
+    # (e.g. "OpenHands/GPT-5.2", "acp-codex/GPT-5.5"). Stable across runs and
+    # never empty, regardless of which optional metadata fields are filled in.
     row: dict[str, Any] = {
-        "id": f"{agent_label}_{meta.get('agent_version', '')}_{meta.get('model', model_dir.name)}",
+        "id": f"{agent_label}/{model_dir.name}",
         "agent_name": meta.get("agent_name", agent_label),
         "agent_type": agent_label,
         "language_model": meta.get("model", model_dir.name),
@@ -143,6 +154,11 @@ def content_hash(df: pd.DataFrame) -> str:
 
 
 def get_remote_hash(api: HfApi) -> str | None:
+    """Best-effort fetch of the previously-published content hash.
+
+    Returns None on missing file, missing repo, or transient network errors —
+    a missing remote hash just forces a publish, which is the safe default.
+    """
     try:
         path = hf_hub_download(
             repo_id=DATASET_REPO, repo_type="dataset", filename=HASH_PATH,
@@ -151,13 +167,40 @@ def get_remote_hash(api: HfApi) -> str | None:
         return Path(path).read_text().strip()
     except (EntryNotFoundError, HfHubHTTPError):
         return None
+    except Exception as e:  # network blip, DNS, etc.
+        logger.warning("Could not fetch remote hash (%s); will publish anyway.", e)
+        return None
 
 
-def dataset_card(df: pd.DataFrame, generated_at: str, source_sha: str | None) -> str:
+def resolve_source_version() -> tuple[str, str, datetime]:
+    """Return (short_sha, version_string, commit_datetime_utc).
+
+    version_string = "YYYY.M.D-<short_sha>" (e.g. 2026.5.29-4c92417).
+    Date comes from the source commit's committer date so the version
+    reflects when the data was finalized, not when CI happened to run.
+    """
+    sha = os.environ.get("GITHUB_SHA") or _git("rev-parse", "HEAD")
+    short = sha[:7]
+    iso = os.environ.get("GITHUB_COMMIT_DATE") or _git(
+        "show", "-s", "--format=%cI", sha
+    )
+    dt = datetime.fromisoformat(iso).astimezone(timezone.utc)
+    version = f"{dt.year}.{dt.month}.{dt.day}-{short}"
+    return short, version, dt
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def dataset_card(
+    df: pd.DataFrame, generated_at: str, source_sha: str, version: str
+) -> str:
     top = df[["language_model", "sdk_version", "agent_name", "average_score",
               "categories_completed", "release_date"]].head(15)
     top_md = top.to_markdown(index=False, floatfmt=".2f") if not top.empty else "_(empty)_"
-    src = f"`{source_sha[:8]}`" if source_sha else "_unknown_"
     return f"""---
 license: apache-2.0
 pretty_name: OpenHands Index Leaderboard
@@ -166,6 +209,12 @@ tags:
 - code
 - agents
 - benchmark
+dataset_info:
+  config_name: default
+  version: {version}
+  description: >-
+    Snapshot of the OpenHands Index leaderboard built from
+    openhands-index-results commit {source_sha} on {generated_at}.
 configs:
 - config_name: default
   data_files:
@@ -181,8 +230,13 @@ on every push to `main`. Matches the table shown at the
 
 ```python
 from datasets import load_dataset
+
+# latest
 ds = load_dataset("{DATASET_REPO}", split="test")
-df = ds.to_pandas()
+ds.info.version          # → "{version}"
+
+# pin to this exact snapshot
+ds = load_dataset("{DATASET_REPO}", split="test", revision="v{version}")
 ```
 
 ## Categories
@@ -198,11 +252,12 @@ df = ds.to_pandas()
 `average_score` is the mean of the per-benchmark scores actually completed.
 `categories_completed` tells you how many benchmarks the model has run.
 
-## Snapshot
+## This snapshot
 
+- Version: **`{version}`**
 - Rows: **{len(df)}**
 - Generated: `{generated_at}`
-- Source commit: {src}
+- Source commit: [`{source_sha}`](https://github.com/OpenHands/openhands-index-results/commit/{source_sha})
 
 ## Top 15 by average score
 
@@ -217,7 +272,13 @@ def main() -> int:
         return 2
 
     api = HfApi(token=token)
-    df = build_dataframe()
+
+    try:
+        df = build_dataframe()
+    except RuntimeError as e:
+        logger.error("%s", e)
+        return 1
+
     new_hash = content_hash(df)
     logger.info("Built %d rows; content hash %s", len(df), new_hash[:12])
 
@@ -233,27 +294,44 @@ def main() -> int:
         logger.error("create_repo failed: %s", e)
         return 1
 
+    short_sha, version, _ = resolve_source_version()
+    source_sha = os.environ.get("GITHUB_SHA") or _git("rev-parse", "HEAD")
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
     buf = io.BytesIO()
     df.to_parquet(buf, index=False)
     parquet_bytes = buf.getvalue()
+    readme_bytes = dataset_card(df, generated_at, source_sha, version).encode("utf-8")
 
-    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-    source_sha = os.environ.get("GITHUB_SHA")
-    readme_bytes = dataset_card(df, generated_at, source_sha).encode("utf-8")
-
-    from huggingface_hub import CommitOperationAdd
     ops = [
         CommitOperationAdd(path_in_repo=PARQUET_PATH, path_or_fileobj=parquet_bytes),
         CommitOperationAdd(path_in_repo=README_PATH, path_or_fileobj=readme_bytes),
         CommitOperationAdd(path_in_repo=HASH_PATH, path_or_fileobj=new_hash.encode()),
     ]
-    short_sha = (source_sha or "")[:7]
-    msg = f"Update leaderboard: {len(df)} models" + (f" (source {short_sha})" if short_sha else "")
-    api.create_commit(
-        repo_id=DATASET_REPO, repo_type="dataset",
-        operations=ops, commit_message=msg,
-    )
-    logger.info("Published %d rows to %s", len(df), DATASET_REPO)
+    try:
+        commit_info = api.create_commit(
+            repo_id=DATASET_REPO, repo_type="dataset",
+            operations=ops,
+            commit_message=f"Update leaderboard v{version} ({len(df)} models)",
+        )
+    except HfHubHTTPError as e:
+        logger.error("create_commit failed: %s", e)
+        return 1
+    logger.info("Published %d rows to %s as v%s", len(df), DATASET_REPO, version)
+
+    # Immutable tag so users can pin: load_dataset(..., revision="v2026.5.29-4c92417")
+    tag = f"v{version}"
+    try:
+        api.create_tag(
+            repo_id=DATASET_REPO, repo_type="dataset",
+            tag=tag, tag_message=f"Leaderboard snapshot from {source_sha}",
+            revision=commit_info.oid,
+            exist_ok=True,
+        )
+        logger.info("Tagged %s", tag)
+    except HfHubHTTPError as e:
+        logger.warning("Could not create tag %s: %s", tag, e)
+
     return 0
 
 

--- a/scripts/requirements-publish.txt
+++ b/scripts/requirements-publish.txt
@@ -1,0 +1,7 @@
+# Pinned dependencies for scripts/publish_hf_dataset.py.
+# Upper bounds prevent silent breakage from major version bumps; the workflow
+# also uses this file as the pip cache key so re-runs skip redundant downloads.
+huggingface_hub>=0.30,<2.0
+pandas>=2.0,<4.0
+pyarrow>=15,<25
+tabulate>=0.9,<1.0


### PR DESCRIPTION
## Summary

Adds a GitHub Action that builds a flat leaderboard parquet from this repo
(`results/` + `alternative_agents/`) and publishes it to the HF Dataset
[`OpenHands/openhands-index`](https://huggingface.co/datasets/OpenHands/openhands-index)
on every push to `main`. After this lands, anyone can do the idiomatic HF thing:

```python
from datasets import load_dataset
ds = load_dataset("OpenHands/openhands-index", split="test")
df = ds.to_pandas()
```

## Why here and not in the Space

Originally I drafted this inside the `openhands-index` HF Space (now-closed [PR #37](https://huggingface.co/spaces/OpenHands/openhands-index/discussions/37)), which would have required a long-lived HF write token sitting in a Space env var. Moving the publisher to this repo means:

- the token lives in GitHub repo secrets (already audited & rotated like the rest of CI),
- the Space goes back to being a pure read-only consumer,
- the Dataset updates the moment new model results are merged here — independent of whether the Space happens to be running.

## Files

- **`scripts/publish_hf_dataset.py`** — reads every `metadata.json` + `scores.json` under `results/` and `alternative_agents/`, builds a 38-column DataFrame (id, model, sdk version, agent label, averages, 5 categories × {score, cost, runtime, logs URL, visualization URL}), writes `test.parquet` + a dataset-card `README.md` + a `.source_hash` to the dataset repo. Skips the push entirely when the hash matches what's already on the Hub (no noisy empty commits).
- **`.github/workflows/publish-hf-dataset.yml`** — runs on `push` to `main` touching `results/**`, `alternative_agents/**`, the script, or the workflow itself. Also `workflow_dispatch` with a `force` input for manual reruns.

## Verified locally

Ran the script against the current `main` and confirmed the numbers match the Space's `/api/leaderboard` output exactly (e.g. claude-opus-4-7 → `average_score=68.18`, `issue_resolution_score=74.2`, etc.). Output: **39 rows, 38 columns**.

## Required setup before merging

1. **Create a fine-grained HF token** at <https://huggingface.co/settings/tokens>:
   - Type: *Fine-grained*
   - Permissions: *Repositories permissions* → add `OpenHands/openhands-index` (Dataset) → **Write access to contents/settings**. Nothing else.
2. **Add it as a repo secret** named `HF_DATASET_TOKEN` in <https://github.com/OpenHands/openhands-index-results/settings/secrets/actions>.
3. Merge. The first run will create the Dataset repo if it doesn't exist.

The dataset repo and the Space share the name `OpenHands/openhands-index` — HF treats Dataset and Space as separate namespaces, so this is fine. Happy to rename if you prefer `OpenHands/openhands-index-leaderboard`.

## Open question for review

The dataset currently includes both `results/` (`agent_name=OpenHands`) **and** `alternative_agents/` (Codex, Gemini CLI, Claude Code, OpenHands Sub-agents) in a single table, distinguished by an `agent_type` column. Let me know if you'd prefer:

- (a) only `results/` (matches the Space's main page exactly — 29 rows), or
- (b) what I have now: everything in one table, filterable via `agent_type` (39 rows), or
- (c) two splits (`test` + `alternative_agents`).

---

_This PR was opened by an AI agent (OpenHands) on behalf of @juanmichelini._


@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/34328d20-6187-4518-9895-08df7ce5dc42)