### PR TITLE
Publish only results/ to HF dataset (exclude alternative_agents)

### DIFF
--- a/.github/workflows/publish-hf-dataset.yml
+++ b/.github/workflows/publish-hf-dataset.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - 'results/**'
-      - 'alternative_agents/**'
       - 'scripts/publish_hf_dataset.py'
       - '.github/workflows/publish-hf-dataset.yml'
   workflow_dispatch:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = scripts

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """
-Build a flat leaderboard table from results/ and alternative_agents/, then
-publish it to the HF Dataset repo `OpenHands/openhands-index` so consumers
-can do:
+Build a flat leaderboard table from results/, then publish it to the HF
+Dataset repo `OpenHands/openhands-index` so consumers can do:
 
     from datasets import load_dataset
     ds = load_dataset("OpenHands/openhands-index", split="test")
@@ -48,29 +47,21 @@ BENCHMARKS = list(BENCHMARK_TO_CATEGORY.keys())
 
 
 def _iter_model_dirs() -> Iterable[tuple[Path, str]]:
-    """Yield (model_dir, agent_label) pairs from results/ and alternative_agents/.
+    """Yield (model_dir, agent_label) pairs from results/.
 
-    Layouts handled:
+    Layout handled:
       results/<model>/{metadata.json,scores.json}          -> agent_label="OpenHands"
-      alternative_agents/<agent_type>/<model>/{...}        -> agent_label="<agent_type>"
 
-    Anything nested deeper than that is ignored; if the layout changes,
-    extend this function rather than the call sites.
+    Alternative agents under `alternative_agents/` are intentionally not
+    published to the HF dataset yet (see #1145). Anything nested deeper than
+    the documented layout is ignored; if the layout changes, extend this
+    function rather than the call sites.
     """
     results_dir = REPO_ROOT / "results"
     if results_dir.is_dir():
         for d in sorted(results_dir.iterdir()):
             if d.is_dir() and (d / "metadata.json").exists():
                 yield d, "OpenHands"
-
-    alt_root = REPO_ROOT / "alternative_agents"
-    if alt_root.is_dir():
-        for agent_type_dir in sorted(alt_root.iterdir()):
-            if not agent_type_dir.is_dir():
-                continue
-            for d in sorted(agent_type_dir.iterdir()):
-                if d.is_dir() and (d / "metadata.json").exists():
-                    yield d, agent_type_dir.name
 
 
 def _load_json(path: Path) -> Any:
@@ -122,8 +113,8 @@ def _flatten(model_dir: Path, agent_label: str) -> dict[str, Any] | None:
         return round(sum(vals) / len(vals), 4) if vals else None
 
     # `id` mirrors the on-disk path, which the repo already treats as unique
-    # (e.g. "OpenHands/GPT-5.2", "acp-codex/GPT-5.5"). Stable across runs and
-    # never empty, regardless of which optional metadata fields are filled in.
+    # (e.g. "OpenHands/GPT-5.2"). Stable across runs and never empty,
+    # regardless of which optional metadata fields are filled in.
     row: dict[str, Any] = {
         "id": f"{agent_label}/{model_dir.name}",
         "agent_name": meta.get("agent_name", agent_label),

--- a/tests/test_publish_hf_dataset.py
+++ b/tests/test_publish_hf_dataset.py
@@ -1,0 +1,70 @@
+"""Tests for the publish_hf_dataset script.
+
+These tests focus on the data-collection surface of the publisher and verify
+that alternative agents are intentionally excluded from the dataset that
+gets pushed to Hugging Face (see issue #1145).
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import publish_hf_dataset
+
+
+def _write_model(model_dir: Path, *, scored: bool = True) -> None:
+    """Write minimal valid metadata.json/scores.json for one model."""
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "metadata.json").write_text(json.dumps({
+        "agent_name": "OpenHands",
+        "model": model_dir.name,
+    }))
+    scores = [{
+        "benchmark": "swe-bench",
+        "score": 0.5 if scored else None,
+        "cost_per_instance": 0.1,
+        "average_runtime": 60,
+    }]
+    (model_dir / "scores.json").write_text(json.dumps(scores))
+
+
+class TestIterModelDirs:
+    """Tests for _iter_model_dirs — the source-of-truth on what gets published."""
+
+    def test_yields_only_results_models(self, tmp_path):
+        _write_model(tmp_path / "results" / "GPT-X")
+        _write_model(tmp_path / "results" / "Claude-Y")
+        # Alternative agents must be ignored even when valid.
+        _write_model(tmp_path / "alternative_agents" / "acp-codex" / "GPT-X")
+        _write_model(tmp_path / "alternative_agents" / "acp-claude" / "Claude-Y")
+
+        with patch.object(publish_hf_dataset, "REPO_ROOT", tmp_path):
+            pairs = list(publish_hf_dataset._iter_model_dirs())
+
+        assert {(d.name, label) for d, label in pairs} == {
+            ("Claude-Y", "OpenHands"),
+            ("GPT-X", "OpenHands"),
+        }
+
+    def test_no_results_dir_yields_nothing(self, tmp_path):
+        _write_model(tmp_path / "alternative_agents" / "acp-codex" / "GPT-X")
+
+        with patch.object(publish_hf_dataset, "REPO_ROOT", tmp_path):
+            assert list(publish_hf_dataset._iter_model_dirs()) == []
+
+
+class TestBuildDataframe:
+    """End-to-end check that the published DataFrame excludes alt agents."""
+
+    def test_dataframe_excludes_alternative_agents(self, tmp_path):
+        _write_model(tmp_path / "results" / "GPT-X")
+        _write_model(tmp_path / "alternative_agents" / "acp-codex" / "GPT-X")
+
+        with patch.object(publish_hf_dataset, "REPO_ROOT", tmp_path):
+            df = publish_hf_dataset.build_dataframe()
+
+        assert list(df["agent_type"].unique()) == ["OpenHands"]
+        assert list(df["id"]) == ["OpenHands/GPT-X"]

--- a/tests/test_publish_hf_dataset.py
+++ b/tests/test_publish_hf_dataset.py
@@ -6,16 +6,13 @@ gets pushed to Hugging Face (see issue #1145).
 """
 
 import json
-import sys
 from pathlib import Path
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 import publish_hf_dataset
 
 
-def _write_model(model_dir: Path, *, scored: bool = True) -> None:
+def _write_model(model_dir: Path) -> None:
     """Write minimal valid metadata.json/scores.json for one model."""
     model_dir.mkdir(parents=True, exist_ok=True)
     (model_dir / "metadata.json").write_text(json.dumps({
@@ -24,7 +21,7 @@ def _write_model(model_dir: Path, *, scored: bool = True) -> None:
     }))
     scores = [{
         "benchmark": "swe-bench",
-        "score": 0.5 if scored else None,
+        "score": 0.5,
         "cost_per_instance": 0.1,
         "average_runtime": 60,
     }]


### PR DESCRIPTION
Fixes #1145.

## Summary

Alternative agents data is not yet ready to be published to Hugging Face. This PR restricts the HF dataset publisher to read only from `results/` and removes `alternative_agents/` from both the workflow trigger and the data collection logic.

## Changes

- **`.github/workflows/publish-hf-dataset.yml`**: Removed `alternative_agents/**` from the `push.paths` trigger so changes to alternative agents no longer cause a republish.
- **`scripts/publish_hf_dataset.py`**: `_iter_model_dirs()` now only yields models from `results/`. Updated the module docstring and an example comment accordingly. The `agent_type`/`agent_label` plumbing is preserved (always `"OpenHands"` now) so re-enabling alt agents later is a one-block change.
- **`tests/test_publish_hf_dataset.py`** (new): Tests that `_iter_model_dirs()` and `build_dataframe()` only include `results/` models and ignore `alternative_agents/`, even when valid metadata/scores exist there.

## Verification

```
$ python -m pytest tests/test_publish_hf_dataset.py -v
...
tests/test_publish_hf_dataset.py::TestIterModelDirs::test_yields_only_results_models PASSED
tests/test_publish_hf_dataset.py::TestIterModelDirs::test_no_results_dir_yields_nothing PASSED
tests/test_publish_hf_dataset.py::TestBuildDataframe::test_dataframe_excludes_alternative_agents PASSED
============================== 3 passed in 0.50s ===============================
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5f4cde9a-8e20-4d7b-b34d-0eb89cc1fa5d)