### PR TITLE
Remove claude-opus-4-8 from complete-models.json

### DIFF
--- a/complete-models.json
+++ b/complete-models.json
@@ -1,9 +1,5 @@
 [
   {
-    "timestamp": "2026-05-28T20:01:05.000+00:00",
-    "model-path": "results/claude-opus-4-8"
-  },
-  {
     "timestamp": "2026-05-22T20:58:48.000+00:00",
     "model-path": "results/Qwen3-Coder-Next"
   },


### PR DESCRIPTION
## Summary

Removes the `claude-opus-4-8` entry from `complete-models.json`. It was added by mistake before the evaluation was completed.

## Changes

- Deleted the `claude-opus-4-8` entry (timestamp `2026-05-28T20:01:05.000+00:00`, `model-path: results/claude-opus-4-8`) from `complete-models.json`.

The resulting JSON remains valid.

Fixes #1156

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/130643c2-50e6-4ba5-8c73-4003b3e6b4c3)