### PR TITLE
Fix HF dataset_info.version format so dataset card loads (closes #1189)

### DIFF
--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -176,19 +176,32 @@ def get_remote_hash(api: HfApi) -> str | None:
         return None
 
 
-def resolve_source_version() -> tuple[str, str, str, datetime]:
-    """Return (full_sha, short_sha, version_string, commit_datetime_utc).
+def resolve_source_version() -> tuple[str, str, str, str, datetime]:
+    """Return (full_sha, short_sha, version_string, info_version, commit_datetime_utc).
 
-    version_string = "YYYY.MM.DD-<short_sha>" (e.g. 2026.05.29-4c92417).
-    Date comes from the source commit's committer date so the version
-    reflects when the data was finalized, not when CI happened to run.
+    ``version_string`` = ``"YYYY.MM.DD-<short_sha>"`` (e.g. ``2026.05.29-4c92417``)
+    is the human-facing version used in tags, commit messages and the rendered
+    dataset card. It embeds the source commit hash so each published snapshot
+    is unambiguously traceable.
+
+    ``info_version`` = ``"YYYY.M.D"`` (digits only, ``x.y.z`` form) is the
+    *machine-facing* version used for the ``dataset_info.version`` YAML field
+    in the dataset card. The HF ``datasets`` library parses that field as a
+    ``datasets.Version`` and rejects anything other than three dot-separated
+    digit groups — including the ``-<short_sha>`` suffix — which used to break
+    ``get_dataset_config_names()`` for the leaderboard dataset (see #1189).
+
+    The date in both versions comes from the source commit's committer date so
+    the version reflects when the data was finalized, not when CI happened to
+    run.
     """
     sha = os.environ.get("GITHUB_SHA") or _git("rev-parse", "HEAD")
     short = sha[:7]
     iso = _git("show", "-s", "--format=%cI", sha)
     dt = datetime.fromisoformat(iso).astimezone(timezone.utc)
     version = f"{dt.year}.{dt.month:02d}.{dt.day:02d}-{short}"
-    return sha, short, version, dt
+    info_version = f"{dt.year}.{dt.month}.{dt.day}"
+    return sha, short, version, info_version, dt
 
 
 def _git(*args: str) -> str:
@@ -198,11 +211,20 @@ def _git(*args: str) -> str:
 
 
 def dataset_card(
-    df: pd.DataFrame, generated_at: str, source_sha: str, version: str
+    df: pd.DataFrame,
+    generated_at: str,
+    source_sha: str,
+    version: str,
+    info_version: str,
 ) -> str:
     top = df[["language_model", "sdk_version", "agent_name", "average_score",
               "categories_completed", "release_date"]].head(15)
     top_md = top.to_markdown(index=False, floatfmt=".2f") if not top.empty else "_(empty)_"
+    # NOTE: ``dataset_info.version`` MUST be a digits-only ``x.y.z`` string —
+    # the HF datasets library parses it as a ``datasets.Version`` and rejects
+    # anything else (e.g. a ``-<short_sha>`` suffix). Using ``info_version``
+    # here keeps ``get_dataset_config_names()`` working; the full ``version``
+    # with the commit hash is kept further down for human-facing display.
     return f"""---
 license: apache-2.0
 pretty_name: OpenHands Index Leaderboard
@@ -213,7 +235,7 @@ tags:
 - benchmark
 dataset_info:
   config_name: default
-  version: {version}
+  version: {info_version}
   description: >-
     Snapshot of the OpenHands Index leaderboard built from
     openhands-index-results commit {source_sha} on {generated_at}.
@@ -297,7 +319,7 @@ def main() -> int:
         return 1
 
     try:
-        source_sha, _, version, _ = resolve_source_version()
+        source_sha, _, version, info_version, _ = resolve_source_version()
     except subprocess.CalledProcessError as e:
         logger.error("Failed to resolve source version: %s", e)
         return 1
@@ -306,7 +328,9 @@ def main() -> int:
     buf = io.BytesIO()
     df.to_parquet(buf, index=False)
     parquet_bytes = buf.getvalue()
-    readme_bytes = dataset_card(df, generated_at, source_sha, version).encode("utf-8")
+    readme_bytes = dataset_card(
+        df, generated_at, source_sha, version, info_version
+    ).encode("utf-8")
 
     ops = [
         CommitOperationAdd(path_in_repo=PARQUET_PATH, path_or_fileobj=parquet_bytes),

--- a/tests/test_publish_hf_dataset.py
+++ b/tests/test_publish_hf_dataset.py
@@ -2,12 +2,19 @@
 
 These tests focus on the data-collection surface of the publisher and verify
 that alternative agents are intentionally excluded from the dataset that
-gets pushed to Hugging Face (see issue #1145).
+gets pushed to Hugging Face (see issue #1145), and that the dataset card
+emits a HF-valid ``dataset_info.version`` (see issue #1189).
 """
 
 import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
+
+import pandas as pd
 
 import publish_hf_dataset
 
@@ -65,3 +72,134 @@ class TestBuildDataframe:
 
         assert list(df["agent_type"].unique()) == ["OpenHands"]
         assert list(df["id"]) == ["OpenHands/GPT-X"]
+
+
+# HF's ``datasets.Version`` accepts exactly three dot-separated digit groups.
+# Mirror the same regex used by the upstream library so the test fails for the
+# exact same inputs that would crash ``get_dataset_config_names()``.
+_HF_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+class TestResolveSourceVersion:
+    """``resolve_source_version`` must return both a tag-style ``version``
+    (with the git short SHA) and a HF-valid ``info_version`` (digits only)."""
+
+    def _run(self, tmp_path, commit_iso):
+        """Run resolve_source_version against a freshly initialised repo whose
+        single commit has the given committer date."""
+        run = lambda *a: subprocess.run(  # noqa: E731
+            a, cwd=tmp_path, check=True, capture_output=True, text=True
+        )
+        run("git", "init", "-q", "-b", "main")
+        run("git", "config", "user.email", "t@t")
+        run("git", "config", "user.name", "t")
+        (tmp_path / "x").write_text("x")
+        run("git", "add", "x")
+        env_run = subprocess.run(
+            ["git", "commit", "-q", "-m", "x"],
+            cwd=tmp_path,
+            env={
+                "GIT_COMMITTER_DATE": commit_iso,
+                "GIT_AUTHOR_DATE": commit_iso,
+                "PATH": os.environ["PATH"],
+                "HOME": str(tmp_path),
+            },
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert env_run.returncode == 0
+        with patch.object(publish_hf_dataset, "REPO_ROOT", tmp_path), \
+                patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GITHUB_SHA", None)
+            return publish_hf_dataset.resolve_source_version()
+
+    def test_info_version_is_digits_only(self, tmp_path):
+        sha, short, version, info_version, dt = self._run(
+            tmp_path, "2026-06-08T12:00:00+0000"
+        )
+
+        # The full ``version`` is still the human-facing string with the SHA.
+        assert version == f"2026.06.08-{short}"
+        assert sha.startswith(short)
+        assert dt == datetime(2026, 6, 8, 12, 0, tzinfo=timezone.utc)
+
+        # ``info_version`` is what gets written to ``dataset_info.version`` —
+        # it must be a plain ``x.y.z`` string of digits or HF's datasets
+        # library will refuse to load the dataset card (issue #1189).
+        assert info_version == "2026.6.8"
+        assert _HF_VERSION_RE.match(info_version), info_version
+
+    def test_info_version_drops_leading_zeros(self, tmp_path):
+        # Single-digit months/days must not be zero-padded — ``06`` would be
+        # a digit string too but using ``2026.6.8`` matches the upstream
+        # ``x.y.z`` convention used in the issue's suggested fix.
+        _, _, _, info_version, _ = self._run(
+            tmp_path, "2026-01-02T00:00:00+0000"
+        )
+        assert info_version == "2026.1.2"
+        assert _HF_VERSION_RE.match(info_version)
+
+
+class TestDatasetCardVersion:
+    """The rendered dataset card must embed the HF-valid ``info_version`` in
+    the YAML frontmatter and keep the SHA-bearing ``version`` for display."""
+
+    def _card(self, version="2026.06.08-525c6b4", info_version="2026.6.8"):
+        return publish_hf_dataset.dataset_card(
+            df=pd.DataFrame(
+                {
+                    "language_model": ["m"],
+                    "sdk_version": ["1"],
+                    "agent_name": ["OpenHands"],
+                    "average_score": [0.5],
+                    "categories_completed": [1],
+                    "release_date": ["2026-06-08"],
+                }
+            ),
+            generated_at="2026-06-08 12:00:00 UTC",
+            source_sha="525c6b4abcdef",
+            version=version,
+            info_version=info_version,
+        )
+
+    def test_yaml_dataset_info_version_is_hf_valid(self):
+        card = self._card()
+
+        # Extract the ``version:`` line under ``dataset_info:`` and assert it
+        # parses as the upstream regex (``x.y.z`` digits) — this is the exact
+        # surface that failed in #1189 with ``2026.06.08-525c6b4``.
+        m = re.search(
+            r"^dataset_info:\s*\n(?:.*\n)*?\s*version:\s*(\S+)\s*$",
+            card,
+            flags=re.MULTILINE,
+        )
+        assert m is not None, "dataset_info.version not found in YAML frontmatter"
+        emitted = m.group(1)
+        assert _HF_VERSION_RE.match(emitted), (
+            f"dataset_info.version {emitted!r} is not a HF-valid x.y.z string"
+        )
+        assert emitted == "2026.6.8"
+        # The git-hash form must never end up in the ``version:`` field even
+        # though the SHA legitimately appears elsewhere (e.g. in the
+        # ``description:`` field that references the source commit).
+        assert "-" not in emitted
+
+    def test_human_version_still_present_in_body(self):
+        # The full ``YYYY.MM.DD-<sha>`` tag-style version is still useful for
+        # humans and for the ``load_dataset(..., revision=...)`` example, so
+        # it must remain in the rendered body even though the YAML uses the
+        # digits-only form.
+        card = self._card()
+        body = card.split("---", 2)[2]
+        assert "2026.06.08-525c6b4" in body
+
+    def test_rejects_card_with_invalid_version_format(self):
+        # Sanity check: if a future change accidentally feeds the SHA-bearing
+        # version back into ``info_version``, this regex assertion fires —
+        # which is exactly what would break HF dataset loading.
+        bad_card = self._card(info_version="2026.06.08-525c6b4")
+        frontmatter = bad_card.split("---", 2)[1]
+        m = re.search(r"version:\s*(\S+)", frontmatter)
+        assert m is not None
+        assert not _HF_VERSION_RE.match(m.group(1))


### PR DESCRIPTION
## Summary

Fixes #1189.

The HuggingFace dataset viewer was failing with:

```
Cannot get the config names for the dataset.
Error code: ConfigNamesError
```

The real root cause (surfaced inside `get_dataset_config_names`) was:

```
ValueError: Invalid version '2026.06.08-525c6b4'. Format should be x.y.z with {x,y,z} being digits.
```

`datasets` parses `dataset_info.version` from the card YAML as a `datasets.Version`, which strictly requires three dot-separated digit groups (`x.y.z`). Our publisher was writing `YYYY.MM.DD-<short_sha>` into that field, so the `-<sha>` suffix made the dataset card unparseable.

## Fix

Per the issue's recommendation (`2026.6.8`), `scripts/publish_hf_dataset.py` now produces two version strings:

| Name | Format | Where it's used |
|---|---|---|
| `version` | `YYYY.MM.DD-<short_sha>` (unchanged) | Tags (`v{version}`), commit message, dataset-card body, `load_dataset(..., revision=...)` example — i.e. everywhere a human/CI needs to identify the snapshot. |
| `info_version` | `YYYY.M.D` (digits-only, valid `x.y.z`) | The YAML `dataset_info.version` field that HF parses with `datasets.Version`. |

So an example card now contains:

```yaml
dataset_info:
  config_name: default
  version: 2026.6.8
```

…while the body still shows `Version: \`2026.06.08-525c6b4\`` and the tag is still `v2026.06.08-525c6b4`, preserving traceability to the exact source commit.

## Tests

Added to `tests/test_publish_hf_dataset.py`:

- `TestResolveSourceVersion` — drives a real local git repo with a controlled `GIT_COMMITTER_DATE`, asserts that `resolve_source_version()` returns the full `YYYY.MM.DD-<sha>` `version` **and** a digits-only `info_version` matching HF's `^\d+\.\d+\.\d+$` regex, including for single-digit months/days (`2026.1.2`).
- `TestDatasetCardVersion` — renders `dataset_card(...)` and asserts:
  - the YAML `dataset_info.version:` line matches HF's `x.y.z` regex (this is the exact surface that broke in #1189);
  - the SHA-bearing `version` is still present in the rendered body for humans / `load_dataset(..., revision=...)`;
  - feeding the old `YYYY.MM.DD-<sha>` form back into `info_version` makes the regex check fail, locking in a regression test.

All 211 tests pass:

```
$ python -m pytest tests/
============================= 211 passed in 0.81s ==============================
```

## Notes on scope

Only `scripts/publish_hf_dataset.py` (the GitHub Actions action that publishes the HF dataset) and its tests are touched. The currently broken `README.md` on the HF dataset will be overwritten the next time `publish-hf-dataset.yml` runs on `main` with this fix in place.

---

_This pull request was created by an AI agent (OpenHands) on behalf of @juanmichelini, addressing the request to "modify the action to use the correct version format"._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3009f147-cc26-4acc-af00-6b482c6ea7f9)