### PR TITLE
Add available attribute to model metadata

### DIFF
--- a/alternative_agents/acp-claude/claude-opus-4-6/metadata.json
+++ b/alternative_agents/acp-claude/claude-opus-4-6/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 5.0,
   "output_price": 25.0,
   "cache_read_price": 0.5,
-  "cache_write_price": 6.25
+  "cache_write_price": 6.25,
+  "available": true
 }

--- a/alternative_agents/acp-claude/claude-opus-4-7/metadata.json
+++ b/alternative_agents/acp-claude/claude-opus-4-7/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 5.0,
   "output_price": 25.0,
   "cache_read_price": 0.5,
-  "cache_write_price": 6.25
+  "cache_write_price": 6.25,
+  "available": true
 }

--- a/alternative_agents/acp-claude/claude-sonnet-4-5/metadata.json
+++ b/alternative_agents/acp-claude/claude-sonnet-4-5/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 3.0,
   "output_price": 15.0,
   "cache_read_price": 0.3,
-  "cache_write_price": 3.75
+  "cache_write_price": 3.75,
+  "available": true
 }

--- a/alternative_agents/acp-codex/GPT-5.4/metadata.json
+++ b/alternative_agents/acp-codex/GPT-5.4/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 2.5,
   "output_price": 15.0,
   "cache_read_price": 0.25,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/alternative_agents/acp-codex/GPT-5.5/metadata.json
+++ b/alternative_agents/acp-codex/GPT-5.5/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 5.0,
   "output_price": 30.0,
   "cache_read_price": 0.5,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/alternative_agents/acp-gemini/Gemini-3-Flash/metadata.json
+++ b/alternative_agents/acp-gemini/Gemini-3-Flash/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 0.5,
   "output_price": 3.0,
   "cache_read_price": null,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/alternative_agents/acp-gemini/Gemini-3.1-Pro/metadata.json
+++ b/alternative_agents/acp-gemini/Gemini-3.1-Pro/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 2.0,
   "output_price": 4.0,
   "cache_read_price": 0.2,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/alternative_agents/openhands_subagents/claude-opus-4-6/metadata.json
+++ b/alternative_agents/openhands_subagents/claude-opus-4-6/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 5.0,
   "output_price": 25.0,
   "cache_read_price": 0.5,
-  "cache_write_price": 6.25
+  "cache_write_price": 6.25,
+  "available": true
 }

--- a/alternative_agents/openhands_subagents/claude-sonnet-4-5/metadata.json
+++ b/alternative_agents/openhands_subagents/claude-sonnet-4-5/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 3.0,
   "output_price": 15.0,
   "cache_read_price": 0.3,
-  "cache_write_price": 3.75
+  "cache_write_price": 3.75,
+  "available": true
 }

--- a/results/DeepSeek-V3.2-Reasoner/metadata.json
+++ b/results/DeepSeek-V3.2-Reasoner/metadata.json
@@ -13,5 +13,6 @@
   "output_price": 2.19,
   "cache_read_price": 0.14,
   "cache_write_price": null,
-  "submission_time": "2026-01-27T18:40:51.252521+00:00"
+  "submission_time": "2026-01-27T18:40:51.252521+00:00",
+  "available": true
 }

--- a/results/DeepSeek-V4-Pro/metadata.json
+++ b/results/DeepSeek-V4-Pro/metadata.json
@@ -13,5 +13,6 @@
   "input_price": 0.435,
   "output_price": 0.87,
   "cache_read_price": 0.003625,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/results/GLM-4.7/metadata.json
+++ b/results/GLM-4.7/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 1.11,
   "cache_read_price": 0.056,
   "cache_write_price": null,
-  "submission_time": "2026-02-09T17:47:05.034520+00:00"
+  "submission_time": "2026-02-09T17:47:05.034520+00:00",
+  "available": true
 }

--- a/results/GLM-5.1/metadata.json
+++ b/results/GLM-5.1/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 3.2,
   "cache_read_price": 0.2,
   "cache_write_price": null,
-  "submission_time": "2026-04-08T20:00:00.000000+00:00"
+  "submission_time": "2026-04-08T20:00:00.000000+00:00",
+  "available": true
 }

--- a/results/GLM-5/metadata.json
+++ b/results/GLM-5/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 3.2,
   "cache_read_price": 0.2,
   "cache_write_price": null,
-  "submission_time": "2026-02-24T23:15:00.000000+00:00"
+  "submission_time": "2026-02-24T23:15:00.000000+00:00",
+  "available": true
 }

--- a/results/GPT-5.2-Codex/metadata.json
+++ b/results/GPT-5.2-Codex/metadata.json
@@ -12,5 +12,6 @@
   "output_price": 14.0,
   "cache_read_price": 0.175,
   "cache_write_price": null,
-  "submission_time": "2026-01-26T23:24:40.642068+00:00"
+  "submission_time": "2026-01-26T23:24:40.642068+00:00",
+  "available": true
 }

--- a/results/GPT-5.2/metadata.json
+++ b/results/GPT-5.2/metadata.json
@@ -12,5 +12,6 @@
   "output_price": 14.0,
   "cache_read_price": 0.175,
   "cache_write_price": null,
-  "submission_time": "2026-01-26T15:55:26.395894+00:00"
+  "submission_time": "2026-01-26T15:55:26.395894+00:00",
+  "available": true
 }

--- a/results/GPT-5.4/metadata.json
+++ b/results/GPT-5.4/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 2.5,
   "output_price": 15.0,
   "cache_read_price": 0.25,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/results/GPT-5.5/metadata.json
+++ b/results/GPT-5.5/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 5.0,
   "output_price": 30.0,
   "cache_read_price": 0.5,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/results/Gemini-3-Flash/metadata.json
+++ b/results/Gemini-3-Flash/metadata.json
@@ -12,5 +12,6 @@
   "output_price": 3.0,
   "cache_read_price": null,
   "cache_write_price": null,
-  "submission_time": "2026-01-26T15:53:51.936941+00:00"
+  "submission_time": "2026-01-26T15:53:51.936941+00:00",
+  "available": true
 }

--- a/results/Gemini-3-Pro/metadata.json
+++ b/results/Gemini-3-Pro/metadata.json
@@ -12,5 +12,6 @@
   "output_price": 12.0,
   "cache_read_price": null,
   "cache_write_price": null,
-  "submission_time": "2026-01-26T15:55:15.726618+00:00"
+  "submission_time": "2026-01-26T15:55:15.726618+00:00",
+  "available": false
 }

--- a/results/Gemini-3.1-Pro/metadata.json
+++ b/results/Gemini-3.1-Pro/metadata.json
@@ -12,5 +12,6 @@
   "output_price": 4.0,
   "cache_read_price": 0.2,
   "cache_write_price": null,
-  "submission_time": "2026-03-04T21:58:35.427592+00:00"
+  "submission_time": "2026-03-04T21:58:35.427592+00:00",
+  "available": true
 }

--- a/results/Gemini-3.5-Flash/metadata.json
+++ b/results/Gemini-3.5-Flash/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 1.5,
   "output_price": 9.0,
   "cache_read_price": 0.15,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/results/Kimi-K2-Thinking/metadata.json
+++ b/results/Kimi-K2-Thinking/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 2.5,
   "cache_read_price": 0.15,
   "cache_write_price": null,
-  "submission_time": "2026-01-26T15:55:37.309255+00:00"
+  "submission_time": "2026-01-26T15:55:37.309255+00:00",
+  "available": true
 }

--- a/results/Kimi-K2.5/metadata.json
+++ b/results/Kimi-K2.5/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 3.0,
   "cache_read_price": 0.1,
   "cache_write_price": null,
-  "submission_time": "2026-01-31T13:38:53.273883+00:00"
+  "submission_time": "2026-01-31T13:38:53.273883+00:00",
+  "available": true
 }

--- a/results/Kimi-K2.6/metadata.json
+++ b/results/Kimi-K2.6/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 4.0,
   "cache_read_price": 0.16,
   "cache_write_price": null,
-  "submission_time": "2026-04-28T16:37:00.000000+00:00"
+  "submission_time": "2026-04-28T16:37:00.000000+00:00",
+  "available": true
 }

--- a/results/MiniMax-M2.1/metadata.json
+++ b/results/MiniMax-M2.1/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 1.2,
   "cache_read_price": null,
   "cache_write_price": null,
-  "submission_time": "2026-01-26T15:55:47.616595+00:00"
+  "submission_time": "2026-01-26T15:55:47.616595+00:00",
+  "available": true
 }

--- a/results/MiniMax-M2.5/metadata.json
+++ b/results/MiniMax-M2.5/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 1.2,
   "cache_read_price": null,
   "cache_write_price": null,
-  "submission_time": "2026-02-11T15:10:02.513451+00:00"
+  "submission_time": "2026-02-11T15:10:02.513451+00:00",
+  "available": true
 }

--- a/results/MiniMax-M2.7/metadata.json
+++ b/results/MiniMax-M2.7/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 1.2,
   "cache_read_price": 0.06,
   "cache_write_price": null,
-  "submission_time": "2026-03-21T00:56:16.165242+00:00"
+  "submission_time": "2026-03-21T00:56:16.165242+00:00",
+  "available": true
 }

--- a/results/MiniMax-M3/metadata.json
+++ b/results/MiniMax-M3/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 0.6,
   "output_price": 2.4,
   "cache_read_price": 0.12,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/results/Minimax-2.7/metadata.json
+++ b/results/Minimax-2.7/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 1.2,
   "cache_read_price": 0.06,
   "cache_write_price": null,
-  "submission_time": "2026-03-21T00:56:16.165242+00:00"
+  "submission_time": "2026-03-21T00:56:16.165242+00:00",
+  "available": true
 }

--- a/results/Nemotron-3-Nano/metadata.json
+++ b/results/Nemotron-3-Nano/metadata.json
@@ -15,5 +15,6 @@
   "output_price": 0.2,
   "cache_read_price": null,
   "cache_write_price": null,
-  "submission_time": "2026-01-27T20:00:30.624153+00:00"
+  "submission_time": "2026-01-27T20:00:30.624153+00:00",
+  "available": true
 }

--- a/results/Nemotron-3-Super/metadata.json
+++ b/results/Nemotron-3-Super/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 0.5,
   "cache_read_price": null,
   "cache_write_price": null,
-  "submission_time": "2026-03-14T04:58:09+00:00"
+  "submission_time": "2026-03-14T04:58:09+00:00",
+  "available": true
 }

--- a/results/Qwen3-Coder-480B/metadata.json
+++ b/results/Qwen3-Coder-480B/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 5.0,
   "cache_read_price": 0.2,
   "cache_write_price": null,
-  "submission_time": "2026-01-26T15:55:58.082973+00:00"
+  "submission_time": "2026-01-26T15:55:58.082973+00:00",
+  "available": true
 }

--- a/results/Qwen3-Coder-Next/metadata.json
+++ b/results/Qwen3-Coder-Next/metadata.json
@@ -13,5 +13,6 @@
   "input_price": 1.0,
   "output_price": 5.0,
   "cache_read_price": 0.2,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/results/Qwen3.5-Flash/metadata.json
+++ b/results/Qwen3.5-Flash/metadata.json
@@ -14,5 +14,6 @@
   "input_price": 0.5,
   "output_price": 2.5,
   "cache_read_price": 0.1,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/results/Qwen3.6-Plus/metadata.json
+++ b/results/Qwen3.6-Plus/metadata.json
@@ -14,5 +14,6 @@
   "input_price": 0.5,
   "output_price": 3.0,
   "cache_read_price": null,
-  "cache_write_price": null
+  "cache_write_price": null,
+  "available": true
 }

--- a/results/Trinity-Large-Thinking/metadata.json
+++ b/results/Trinity-Large-Thinking/metadata.json
@@ -14,5 +14,6 @@
   "output_price": 0.9,
   "cache_read_price": null,
   "cache_write_price": null,
-  "submission_time": "2026-04-08T00:00:00.000000+00:00"
+  "submission_time": "2026-04-08T00:00:00.000000+00:00",
+  "available": true
 }

--- a/results/claude-fable-5/metadata.json
+++ b/results/claude-fable-5/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 10.0,
   "output_price": 50.0,
   "cache_read_price": 1.0,
-  "cache_write_price": 12.5
+  "cache_write_price": 12.5,
+  "available": false
 }

--- a/results/claude-opus-4-5/metadata.json
+++ b/results/claude-opus-4-5/metadata.json
@@ -12,5 +12,6 @@
   "output_price": 25.0,
   "cache_read_price": 0.5,
   "cache_write_price": 6.25,
-  "submission_time": "2026-01-27T01:24:15.735789+00:00"
+  "submission_time": "2026-01-27T01:24:15.735789+00:00",
+  "available": true
 }

--- a/results/claude-opus-4-6/metadata.json
+++ b/results/claude-opus-4-6/metadata.json
@@ -12,5 +12,6 @@
   "output_price": 25.0,
   "cache_read_price": 0.5,
   "cache_write_price": 6.25,
-  "submission_time": "2026-02-09T01:41:16.609835+00:00"
+  "submission_time": "2026-02-09T01:41:16.609835+00:00",
+  "available": true
 }

--- a/results/claude-opus-4-7/metadata.json
+++ b/results/claude-opus-4-7/metadata.json
@@ -12,5 +12,6 @@
   "output_price": 25.0,
   "cache_read_price": 0.5,
   "cache_write_price": 6.25,
-  "submission_time": "2026-04-16T14:58:54.542729+00:00"
+  "submission_time": "2026-04-16T14:58:54.542729+00:00",
+  "available": true
 }

--- a/results/claude-opus-4-8/metadata.json
+++ b/results/claude-opus-4-8/metadata.json
@@ -11,5 +11,6 @@
   "input_price": 5.0,
   "output_price": 25.0,
   "cache_read_price": 0.5,
-  "cache_write_price": 6.25
+  "cache_write_price": 6.25,
+  "available": true
 }

--- a/results/claude-sonnet-4-5/metadata.json
+++ b/results/claude-sonnet-4-5/metadata.json
@@ -12,5 +12,6 @@
   "output_price": 15.0,
   "cache_read_price": 0.3,
   "cache_write_price": 3.75,
-  "submission_time": "2026-01-26T16:02:48.428351+00:00"
+  "submission_time": "2026-01-26T16:02:48.428351+00:00",
+  "available": true
 }

--- a/results/claude-sonnet-4-6/metadata.json
+++ b/results/claude-sonnet-4-6/metadata.json
@@ -12,5 +12,6 @@
   "output_price": 15.0,
   "cache_read_price": 0.3,
   "cache_write_price": 3.75,
-  "submission_time": "2026-02-24T23:15:00.000000+00:00"
+  "submission_time": "2026-02-24T23:15:00.000000+00:00",
+  "available": true
 }

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -403,6 +403,7 @@ class Metadata(BaseModel):
     parameter_count_b: Optional[float] = Field(None, description="Total model parameter count in billions. Required for open-weights models.")
     active_parameter_count_b: Optional[float] = Field(None, description="Active parameter count in billions (for MoE models)")
     hide_from_leaderboard: bool = Field(default=False, description="Whether to hide this model from the public leaderboard")
+    available: bool = Field(default=True, description="Whether the model is currently available from the provider")
     input_price: float = Field(..., gt=0, description="Input price per million tokens in USD")
     output_price: float = Field(..., gt=0, description="Output price per million tokens in USD")
     cache_read_price: Optional[float] = Field(None, gt=0, description="Cache read price per million tokens in USD (None if not supported)")
@@ -466,6 +467,25 @@ class Metadata(BaseModel):
             if v != expected_dir_name:
                 raise ValueError(
                     f"directory_name '{v}' does not match expected model name '{expected_dir_name}'"
+                )
+        return v
+
+    @field_validator("available")
+    @classmethod
+    def validate_available(cls, v: bool, info) -> bool:
+        """Ensure available is set correctly for known unavailable models."""
+        model = info.data.get("model")
+        if model is not None:
+            unavailable_models = {Model.GEMINI_3_PRO, Model.CLAUDE_FABLE_5}
+            if model in unavailable_models and v is not False:
+                raise ValueError(
+                    f"Model '{model.value}' is not available from the provider. "
+                    f"'available' must be set to False."
+                )
+            if model not in unavailable_models and v is not True:
+                raise ValueError(
+                    f"Model '{model.value}' is available from the provider. "
+                    f"'available' must be set to True."
                 )
         return v
 

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -935,6 +935,170 @@ class TestMetadataSchema:
         assert valid is False
         assert "agent_name" in msg.lower()
 
+    def test_available_defaults_to_true(self, tmp_path):
+        """Test that available defaults to True when not specified."""
+        metadata = {
+            "agent_name": "OpenHands",
+            "agent_version": "v1.0.0",
+            "model": "GPT-5.2",
+            "country": "us",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "directory_name": "GPT-5.2",
+            "release_date": "2025-12-11",
+            "supports_vision": True,
+            "input_price": 0.1,
+            "output_price": 0.1
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is True
+        assert msg == "OK"
+
+    def test_available_explicitly_true(self, tmp_path):
+        """Test that available=True passes validation for an available model."""
+        metadata = {
+            "agent_name": "OpenHands",
+            "agent_version": "v1.0.0",
+            "model": "GPT-5.2",
+            "country": "us",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "directory_name": "GPT-5.2",
+            "release_date": "2025-12-11",
+            "supports_vision": True,
+            "input_price": 0.1,
+            "output_price": 0.1,
+            "available": True
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is True
+        assert msg == "OK"
+
+    def test_available_false_for_gemini_3_pro(self, tmp_path):
+        """Test that available=False is required for Gemini-3-Pro."""
+        metadata = {
+            "agent_name": "OpenHands",
+            "agent_version": "v1.0.0",
+            "model": "Gemini-3-Pro",
+            "country": "us",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "directory_name": "Gemini-3-Pro",
+            "release_date": "2025-11-18",
+            "supports_vision": True,
+            "input_price": 2.0,
+            "output_price": 12.0,
+            "cache_read_price": None,
+            "cache_write_price": None,
+            "available": False
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is True
+        assert msg == "OK"
+
+    def test_available_true_for_gemini_3_pro_fails(self, tmp_path):
+        """Test that available=True for Gemini-3-Pro is rejected."""
+        metadata = {
+            "agent_name": "OpenHands",
+            "agent_version": "v1.0.0",
+            "model": "Gemini-3-Pro",
+            "country": "us",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "directory_name": "Gemini-3-Pro",
+            "release_date": "2025-11-18",
+            "supports_vision": True,
+            "input_price": 2.0,
+            "output_price": 12.0,
+            "cache_read_price": None,
+            "cache_write_price": None,
+            "available": True
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is False
+        assert "not available" in msg.lower() or "false" in msg.lower()
+
+    def test_available_false_for_claude_fable_5(self, tmp_path):
+        """Test that available=False is required for claude-fable-5."""
+        metadata = {
+            "agent_name": "OpenHands",
+            "agent_version": "v1.18.1",
+            "model": "claude-fable-5",
+            "country": "us",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "directory_name": "claude-fable-5",
+            "release_date": "2026-06-09",
+            "supports_vision": True,
+            "input_price": 10.0,
+            "output_price": 50.0,
+            "available": False
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is True
+        assert msg == "OK"
+
+    def test_available_true_for_claude_fable_5_fails(self, tmp_path):
+        """Test that available=True for claude-fable-5 is rejected."""
+        metadata = {
+            "agent_name": "OpenHands",
+            "agent_version": "v1.18.1",
+            "model": "claude-fable-5",
+            "country": "us",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "directory_name": "claude-fable-5",
+            "release_date": "2026-06-09",
+            "supports_vision": True,
+            "input_price": 10.0,
+            "output_price": 50.0,
+            "available": True
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is False
+        assert "not available" in msg.lower() or "false" in msg.lower()
+
+    def test_available_false_for_available_model_fails(self, tmp_path):
+        """Test that available=False for an available model is rejected."""
+        metadata = {
+            "agent_name": "OpenHands",
+            "agent_version": "v1.0.0",
+            "model": "GPT-5.2",
+            "country": "us",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "directory_name": "GPT-5.2",
+            "release_date": "2025-12-11",
+            "supports_vision": True,
+            "input_price": 0.1,
+            "output_price": 0.1,
+            "available": False
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
+        assert valid is False
+        assert "available" in msg.lower()
+
 
 class TestScoreEntrySchema:
     """Tests for ScoreEntry schema validation."""


### PR DESCRIPTION
## Summary

Add an `available` attribute to all model metadata entries to indicate whether a model is currently available from its provider.

## Changes Made

1. **`scripts/validate_schema.py`**: Added `available` field (default `true`) to the `Metadata` Pydantic model, with a validator that enforces:
   - `available: false` for `gemini-3-pro` and `claude-fable-5` (not currently available from their providers)
   - `available: true` for all other models

2. **All 44 `metadata.json` files** (both `results/` and `alternative_agents/`): Added the `available` field (`true` for all models except `gemini-3-pro` and `claude-fable-5` which are `false`).

3. **`tests/test_validate_schema.py`**: Added 7 tests covering:
   - `available` defaults to `true` when not specified
   - `available: true` passes for available models
   - `available: false` is accepted for `gemini-3-pro`
   - `available: true` is rejected for `gemini-3-pro`
   - `available: false` is accepted for `claude-fable-5`
   - `available: true` is rejected for `claude-fable-5`
   - `available: false` is rejected for available models

## Verification

- Schema validation passes (`python scripts/validate_schema.py`)
- All 124 tests pass (`pytest tests/test_validate_schema.py -v`)

Fixes #1211

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/012c2ad0-495b-4855-b6fd-328537c0b398)