### PR TITLE
Fix update-complete-models.yml: replace missing SDK_PAT secret

### DIFF
--- a/.github/workflows/update-complete-models.yml
+++ b/.github/workflows/update-complete-models.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: OpenHands/software-agent-sdk
-          token: ${{ secrets.SDK_PAT }}
+          token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
           path: software-agent-sdk
 
       - name: Update verified_models.py in place
@@ -123,7 +123,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           path: software-agent-sdk
-          token: ${{ secrets.SDK_PAT }}
+          token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
           branch: automated/update-verified-models
           delete-branch: true
           commit-message: "Update verified_models.py with latest completed benchmark models"


### PR DESCRIPTION
Fixes #1207

The `update-verified-models` job in the workflow was failing with:
```
##[error]Input required and not supplied: token
```

The `secrets.SDK_PAT` referenced in the "Checkout software-agent-sdk" and "Create PR in software-agent-sdk" steps is not configured in this repository. The credential cleanup in PR #1193 renamed `PAT_TOKEN` to `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` but missed the `SDK_PAT` references.

**Changes:**
- Replace `${{ secrets.SDK_PAT }}` with `${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}` in both the checkout and create-pull-request steps of the `update-verified-models` job.

The `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` secret is confirmed working — it's already used successfully for checking out the `OpenHands/docs` repository in the same workflow.

_This PR was created by an AI agent (OpenHands) on behalf of [juanmichelini]._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ea4f84cb-a28f-4923-ba8f-aa6ef7c311ad)