### PR TITLE
fix(generate_recommended_models): skip models with available=false

### DIFF
--- a/scripts/generate_recommended_models.py
+++ b/scripts/generate_recommended_models.py
@@ -159,6 +159,9 @@ def collect_model_summaries(
         if not isinstance(scores, list) or not isinstance(metadata, dict):
             continue
 
+        if metadata.get("available") is False:
+            continue
+
         benchmarks_seen = {
             entry.get("benchmark")
             for entry in scores

--- a/tests/test_generate_recommended_models.py
+++ b/tests/test_generate_recommended_models.py
@@ -43,12 +43,14 @@ def _write_model(
     model: str,
     scores: list[dict],
     openness: str = "closed_api_available",
+    available: bool = True,
 ) -> None:
     model_dir = parent / name
     model_dir.mkdir(parents=True)
-    (model_dir / "metadata.json").write_text(
-        json.dumps({"model": model, "openness": openness, "directory_name": name})
-    )
+    meta = {"model": model, "openness": openness, "directory_name": name}
+    if available is False:
+        meta["available"] = False
+    (model_dir / "metadata.json").write_text(json.dumps(meta))
     (model_dir / "scores.json").write_text(json.dumps(scores))
 
 
@@ -70,6 +72,23 @@ def test_collect_returns_complete_models_only(tmp_path: Path) -> None:
         {"benchmark": "swt-bench", "score": 30.0, "metric": "accuracy"},
     ]
     _write_model(results, "GPT-5.4", "GPT-5.4", partial_scores)
+
+    summaries = collect_model_summaries(results)
+    assert {s.model for s in summaries} == {"claude-opus-4-7"}
+
+
+def test_collect_skips_unavailable_models(tmp_path: Path) -> None:
+    results = tmp_path / "results"
+    results.mkdir()
+
+    _write_model(results, "claude-opus-4-7", "claude-opus-4-7", _full_scores({}))
+    _write_model(
+        results,
+        "Gemini-3-Pro",
+        "Gemini-3-Pro",
+        _full_scores({}),
+        available=False,
+    )
 
     summaries = collect_model_summaries(results)
     assert {s.model for s in summaries} == {"claude-opus-4-7"}


### PR DESCRIPTION
Fixes #1214

The recommend-models action (`scripts/generate_recommended_models.py`) should only consider models that are currently available from their provider. This change safely skips any model whose `metadata.json` has `available: false`.

## Changes

- `scripts/generate_recommended_models.py`: Added a guard in `collect_model_summaries` that skips models with `available: false` in their metadata.
- `tests/test_generate_recommended_models.py`: Added `test_collect_skips_unavailable_models` to verify unavailable models are excluded, and updated the `_write_model` helper to support writing the `available` field.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/42f5dbd8-52eb-4523-b501-848e26d49287)