### PR TITLE
Publish per-instance results as an `instances` config on HF

### DIFF
--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
 """
-Build a flat leaderboard table from results/, then publish it to the HF
-Dataset repo `OpenHands/openhands-index` so consumers can do:
+Build the OpenHands Index dataset on the HF Hub from ``results/`` and
+publish two configs in lockstep:
+
+* ``default``   — one row per model (leaderboard parquet at ``test.parquet``)
+* ``instances`` — one row per (model × benchmark × instance), sourced from
+  ``results/<model>/instance_results/<benchmark>.json`` sidecars
+  (parquet at ``instances.parquet``)
+
+Consumers do:
 
     from datasets import load_dataset
     ds = load_dataset("OpenHands/openhands-index", split="test")
+    instances = load_dataset("OpenHands/openhands-index", "instances", split="test")
 
 Run from CI on every push to main. Requires HF_TOKEN env var (fine-grained
 token, write-scoped to OpenHands/openhands-index dataset only).
@@ -33,6 +41,7 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DATASET_REPO = os.environ.get("DATASET_REPO", "OpenHands/openhands-index")
 PARQUET_PATH = "test.parquet"
+INSTANCES_PARQUET_PATH = "instances.parquet"
 README_PATH = "README.md"
 HASH_PATH = ".source_hash"  # stored in the dataset to detect no-op runs
 
@@ -44,6 +53,7 @@ BENCHMARK_TO_CATEGORY = {
     "gaia": "Information Gathering",
 }
 BENCHMARKS = list(BENCHMARK_TO_CATEGORY.keys())
+INSTANCE_RESULTS_DIRNAME = "instance_results"
 
 
 def _iter_model_dirs() -> Iterable[tuple[Path, str]]:
@@ -152,9 +162,163 @@ def build_dataframe() -> pd.DataFrame:
     return df
 
 
-def content_hash(df: pd.DataFrame) -> str:
-    payload = df.reindex(sorted(df.columns), axis=1).to_csv(index=False, float_format="%.10g").encode("utf-8")
-    return hashlib.sha256(payload).hexdigest()
+# Columns for the ``instances`` config. Declared explicitly (rather than
+# inferred from the first row) so an all-empty publish still produces a
+# parquet with the documented schema, and so downstream consumers can rely
+# on column order. Keep this in sync with the dataset card.
+INSTANCES_COLUMNS = [
+    "id",
+    "agent_name",
+    "agent_type",
+    "language_model",
+    "benchmark",
+    "category",
+    "instance_id",
+    "resolved",
+    "cost",
+]
+
+
+def _iter_instance_results_files() -> Iterable[tuple[Path, str, str, Path]]:
+    """Yield (model_dir, agent_label, benchmark, sidecar_path) for every
+    ``results/<model>/instance_results/<benchmark>.json`` sidecar.
+
+    Mirrors the policy in ``_iter_model_dirs``: only ``results/`` is
+    published (see issue #1145). Sidecars whose stem isn't a known
+    benchmark are skipped — schema validation lives in
+    ``scripts/validate_schema.py`` and runs in its own CI job, so we don't
+    duplicate it here.
+    """
+    for model_dir, agent_label in _iter_model_dirs():
+        instance_dir = model_dir / INSTANCE_RESULTS_DIRNAME
+        if not instance_dir.is_dir():
+            continue
+        for sidecar in sorted(instance_dir.glob("*.json")):
+            benchmark = sidecar.stem
+            if benchmark not in BENCHMARK_TO_CATEGORY:
+                logger.info(
+                    "Skipping unknown benchmark sidecar %s", sidecar.relative_to(REPO_ROOT)
+                )
+                continue
+            yield model_dir, agent_label, benchmark, sidecar
+
+
+def _instance_rows(
+    model_dir: Path, agent_label: str, benchmark: str, sidecar: Path
+) -> list[dict[str, Any]]:
+    """Flatten one ``instance_results/<benchmark>.json`` sidecar into rows.
+
+    The sidecar shape is ``{instance_id: {"resolved": bool|null, "cost": number|null}}``
+    (validated by ``validate_schema.py``). Malformed or non-dict entries are
+    skipped with a warning rather than failing the publish — the per-instance
+    config is best-effort, and a single bad sidecar shouldn't take down the
+    leaderboard push.
+    """
+    try:
+        data = _load_json(sidecar)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        logger.warning("Skipping %s: %s", sidecar.relative_to(REPO_ROOT), e)
+        return []
+
+    if not isinstance(data, dict):
+        logger.warning("Skipping %s: top-level value is not a JSON object", sidecar.relative_to(REPO_ROOT))
+        return []
+
+    try:
+        meta = _load_json(model_dir / "metadata.json")
+    except (FileNotFoundError, json.JSONDecodeError):
+        meta = {}
+
+    row_id = f"{agent_label}/{model_dir.name}"
+    agent_name = meta.get("agent_name", agent_label)
+    language_model = meta.get("model", model_dir.name)
+    category = BENCHMARK_TO_CATEGORY[benchmark]
+
+    rows: list[dict[str, Any]] = []
+    for instance_id, outcome in data.items():
+        if not isinstance(instance_id, str) or not isinstance(outcome, dict):
+            continue
+        resolved = outcome.get("resolved")
+        cost = outcome.get("cost")
+        # Preserve schema types: resolved is bool|None, cost is float|None.
+        if resolved is not None and not isinstance(resolved, bool):
+            resolved = None
+        if cost is not None and (isinstance(cost, bool) or not isinstance(cost, (int, float))):
+            cost = None
+        rows.append({
+            "id": row_id,
+            "agent_name": agent_name,
+            "agent_type": agent_label,
+            "language_model": language_model,
+            "benchmark": benchmark,
+            "category": category,
+            "instance_id": instance_id,
+            "resolved": resolved,
+            "cost": float(cost) if cost is not None else None,
+        })
+    return rows
+
+
+def build_instances_dataframe() -> pd.DataFrame:
+    """Build the long-form per-instance table for the ``instances`` config.
+
+    Returns an empty DataFrame (with the documented schema) when no sidecars
+    are present, rather than raising — unlike the leaderboard, an empty
+    instances table is a legitimate state (e.g. before #1219 landed).
+    """
+    rows: list[dict[str, Any]] = []
+    for model_dir, label, benchmark, sidecar in _iter_instance_results_files():
+        rows.extend(_instance_rows(model_dir, label, benchmark, sidecar))
+
+    if not rows:
+        return pd.DataFrame({c: [] for c in INSTANCES_COLUMNS}).astype({
+            "id": "string",
+            "agent_name": "string",
+            "agent_type": "string",
+            "language_model": "string",
+            "benchmark": "string",
+            "category": "string",
+            "instance_id": "string",
+            "resolved": "boolean",
+            "cost": "float64",
+        })
+
+    df = pd.DataFrame(rows, columns=INSTANCES_COLUMNS)
+    # Nullable dtypes keep ``resolved=None`` / ``cost=None`` round-trippable
+    # through parquet without coercing to NaN/False.
+    df = df.astype({
+        "id": "string",
+        "agent_name": "string",
+        "agent_type": "string",
+        "language_model": "string",
+        "benchmark": "string",
+        "category": "string",
+        "instance_id": "string",
+        "resolved": "boolean",
+        "cost": "float64",
+    })
+    df = df.sort_values(["id", "benchmark", "instance_id"], kind="stable").reset_index(drop=True)
+    return df
+
+
+def content_hash(*dfs: pd.DataFrame) -> str:
+    """Hash all published DataFrames together so sidecar-only updates (which
+    leave the leaderboard table unchanged) still trigger a publish.
+
+    Accepts a variable number of DataFrames in publish order; each is
+    serialised with stable column order and joined by a separator to
+    prevent collisions where the same bytes could be split differently
+    between tables.
+    """
+    h = hashlib.sha256()
+    for i, df in enumerate(dfs):
+        if i:
+            h.update(b"\n--\n")
+        payload = df.reindex(sorted(df.columns), axis=1).to_csv(
+            index=False, float_format="%.10g"
+        ).encode("utf-8")
+        h.update(payload)
+    return h.hexdigest()
 
 
 def get_remote_hash(api: HfApi) -> str | None:
@@ -216,10 +380,12 @@ def dataset_card(
     source_sha: str,
     version: str,
     info_version: str,
+    instances_df: pd.DataFrame | None = None,
 ) -> str:
     top = df[["language_model", "sdk_version", "agent_name", "average_score",
               "categories_completed", "release_date"]].head(15)
     top_md = top.to_markdown(index=False, floatfmt=".2f") if not top.empty else "_(empty)_"
+    instances_rows = 0 if instances_df is None else len(instances_df)
     # NOTE: ``dataset_info.version`` MUST be a digits-only ``x.y.z`` string —
     # the HF datasets library parses it as a ``datasets.Version`` and rejects
     # anything else (e.g. a ``-<short_sha>`` suffix). Using ``info_version``
@@ -234,16 +400,26 @@ tags:
 - agents
 - benchmark
 dataset_info:
-  config_name: default
+- config_name: default
   version: {info_version}
   description: >-
     Snapshot of the OpenHands Index leaderboard built from
     openhands-index-results commit {source_sha} on {generated_at}.
+- config_name: instances
+  version: {info_version}
+  description: >-
+    Per-instance benchmark outcomes (resolved/cost) for every model in the
+    `default` config, sourced from `results/<model>/instance_results/*.json`
+    sidecars at commit {source_sha}.
 configs:
 - config_name: default
   data_files:
   - split: test
     path: test.parquet
+- config_name: instances
+  data_files:
+  - split: test
+    path: instances.parquet
 ---
 
 # OpenHands Index — Leaderboard Snapshot
@@ -255,9 +431,12 @@ on every push to `main`. Matches the table shown at the
 ```python
 from datasets import load_dataset
 
-# latest
+# leaderboard (one row per model)
 ds = load_dataset("{DATASET_REPO}", split="test")
 ds.info.version          # → "{version}"
+
+# per-instance outcomes (one row per model × instance)
+instances = load_dataset("{DATASET_REPO}", "instances", split="test")
 
 # pin to this exact snapshot
 ds = load_dataset("{DATASET_REPO}", split="test", revision="v{version}")
@@ -276,10 +455,34 @@ ds = load_dataset("{DATASET_REPO}", split="test", revision="v{version}")
 `average_score` is the mean of the per-benchmark scores actually completed.
 `categories_completed` tells you how many benchmarks the model has run.
 
+## Configs
+
+### `default` — leaderboard (one row per model)
+
+The aggregate table backing the leaderboard Space. Use this for ranking,
+averages, and per-category scores.
+
+### `instances` — per-instance outcomes (one row per model × benchmark instance)
+
+Long-form table of every benchmark instance's outcome for every model in
+`default`. Join to `default` on `id`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | string | Matches `default.id` (e.g. `OpenHands/GPT-5.5`) |
+| `agent_name` | string | Display name from `metadata.json` |
+| `agent_type` | string | Currently always `OpenHands` (see [#1145](https://github.com/OpenHands/openhands-index-results/issues/1145)) |
+| `language_model` | string | LLM identifier |
+| `benchmark` | string | One of `swe-bench`, `swe-bench-multimodal`, `commit0`, `swt-bench`, `gaia` |
+| `category` | string | Human-facing category label |
+| `instance_id` | string | Benchmark-specific instance ID |
+| `resolved` | bool? | `true` / `false` / `null` when the archive didn't record an outcome |
+| `cost` | float? | USD; `null` when unavailable |
+
 ## This snapshot
 
 - Version: **`{version}`**
-- Rows: **{len(df)}**
+- Rows: **{len(df)}** (`default`) · **{instances_rows}** (`instances`)
 - Generated: `{generated_at}`
 - Source commit: [`{source_sha}`](https://github.com/OpenHands/openhands-index-results/commit/{source_sha})
 
@@ -303,8 +506,13 @@ def main() -> int:
         logger.error("%s", e)
         return 1
 
-    new_hash = content_hash(df)
-    logger.info("Built %d rows; content hash %s", len(df), new_hash[:12])
+    instances_df = build_instances_dataframe()
+
+    new_hash = content_hash(df, instances_df)
+    logger.info(
+        "Built %d leaderboard rows + %d instance rows; content hash %s",
+        len(df), len(instances_df), new_hash[:12],
+    )
 
     remote_hash = get_remote_hash(api)
     force = os.environ.get("FORCE", "").lower() in {"1", "true", "yes"}
@@ -328,12 +536,19 @@ def main() -> int:
     buf = io.BytesIO()
     df.to_parquet(buf, index=False)
     parquet_bytes = buf.getvalue()
+
+    instances_buf = io.BytesIO()
+    instances_df.to_parquet(instances_buf, index=False)
+    instances_parquet_bytes = instances_buf.getvalue()
+
     readme_bytes = dataset_card(
-        df, generated_at, source_sha, version, info_version
+        df, generated_at, source_sha, version, info_version,
+        instances_df=instances_df,
     ).encode("utf-8")
 
     ops = [
         CommitOperationAdd(path_in_repo=PARQUET_PATH, path_or_fileobj=parquet_bytes),
+        CommitOperationAdd(path_in_repo=INSTANCES_PARQUET_PATH, path_or_fileobj=instances_parquet_bytes),
         CommitOperationAdd(path_in_repo=README_PATH, path_or_fileobj=readme_bytes),
         CommitOperationAdd(path_in_repo=HASH_PATH, path_or_fileobj=new_hash.encode()),
     ]
@@ -341,7 +556,10 @@ def main() -> int:
         commit_info = api.create_commit(
             repo_id=DATASET_REPO, repo_type="dataset",
             operations=ops,
-            commit_message=f"Update leaderboard v{version} ({len(df)} models)",
+            commit_message=(
+                f"Update leaderboard v{version} "
+                f"({len(df)} models, {len(instances_df)} instance rows)"
+            ),
         )
     except HfHubHTTPError as e:
         logger.error("create_commit failed: %s", e)

--- a/tests/test_publish_hf_dataset.py
+++ b/tests/test_publish_hf_dataset.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pandas as pd
+import pytest
 
 import publish_hf_dataset
 
@@ -33,6 +34,13 @@ def _write_model(model_dir: Path) -> None:
         "average_runtime": 60,
     }]
     (model_dir / "scores.json").write_text(json.dumps(scores))
+
+
+def _write_sidecar(model_dir: Path, benchmark: str, entries: dict) -> None:
+    """Write a results/<model>/instance_results/<benchmark>.json sidecar."""
+    instance_dir = model_dir / "instance_results"
+    instance_dir.mkdir(parents=True, exist_ok=True)
+    (instance_dir / f"{benchmark}.json").write_text(json.dumps(entries))
 
 
 class TestIterModelDirs:
@@ -203,3 +211,212 @@ class TestDatasetCardVersion:
         m = re.search(r"version:\s*(\S+)", frontmatter)
         assert m is not None
         assert not _HF_VERSION_RE.match(m.group(1))
+
+
+class TestInstancesDataframe:
+    """Tests for ``build_instances_dataframe`` — the per-instance config that
+    gets published alongside the leaderboard. The policy from #1145 (only
+    ``results/`` is published) must apply here too, and the schema must
+    survive an end-to-end parquet round-trip with ``None`` values for both
+    ``resolved`` and ``cost``.
+    """
+
+    def test_excludes_alternative_agents(self, tmp_path):
+        # Both trees have valid sidecars; only the ``results/`` one should
+        # surface in the published instances table.
+        _write_model(tmp_path / "results" / "GPT-X")
+        _write_sidecar(
+            tmp_path / "results" / "GPT-X",
+            "swe-bench",
+            {"django__django-1": {"resolved": True, "cost": 0.1}},
+        )
+        _write_model(tmp_path / "alternative_agents" / "acp-codex" / "GPT-X")
+        _write_sidecar(
+            tmp_path / "alternative_agents" / "acp-codex" / "GPT-X",
+            "swe-bench",
+            {"django__django-2": {"resolved": True, "cost": 0.2}},
+        )
+
+        with patch.object(publish_hf_dataset, "REPO_ROOT", tmp_path):
+            df = publish_hf_dataset.build_instances_dataframe()
+
+        assert list(df["id"].unique()) == ["OpenHands/GPT-X"]
+        assert list(df["instance_id"]) == ["django__django-1"]
+
+    def test_flattens_multiple_benchmarks_per_model(self, tmp_path):
+        # Each sidecar contributes one row per instance; the discriminator
+        # column distinguishes them.
+        m = tmp_path / "results" / "GPT-X"
+        _write_model(m)
+        _write_sidecar(m, "swe-bench", {
+            "a": {"resolved": True, "cost": 0.1},
+            "b": {"resolved": False, "cost": 0.2},
+        })
+        _write_sidecar(m, "gaia", {
+            "g1": {"resolved": None, "cost": None},
+        })
+        # A non-benchmark stem in the sidecar dir must be skipped, not
+        # crash — the script intentionally doesn't re-validate schemas.
+        _write_sidecar(m, "not-a-real-benchmark", {"x": {"resolved": True, "cost": 0.0}})
+
+        with patch.object(publish_hf_dataset, "REPO_ROOT", tmp_path):
+            df = publish_hf_dataset.build_instances_dataframe()
+
+        assert len(df) == 3
+        assert set(df["benchmark"]) == {"swe-bench", "gaia"}
+        # ``category`` is derived from the same mapping used by the
+        # leaderboard so the two configs stay in sync.
+        assert set(df["category"]) == {"Issue Resolution", "Information Gathering"}
+        # All required columns are present and ordered deterministically.
+        assert list(df.columns) == publish_hf_dataset.INSTANCES_COLUMNS
+
+    def test_preserves_null_resolved_and_cost(self, tmp_path):
+        # The sidecar schema explicitly allows ``null`` for both fields when
+        # the archive didn't record an outcome — the published parquet must
+        # preserve that nullability rather than coercing to ``False`` / ``NaN``.
+        m = tmp_path / "results" / "GPT-X"
+        _write_model(m)
+        _write_sidecar(m, "swe-bench", {
+            "known": {"resolved": True, "cost": 0.5},
+            "unknown_outcome": {"resolved": None, "cost": 0.3},
+            "unknown_cost": {"resolved": False, "cost": None},
+        })
+
+        with patch.object(publish_hf_dataset, "REPO_ROOT", tmp_path):
+            df = publish_hf_dataset.build_instances_dataframe()
+
+        df = df.set_index("instance_id")
+        # ``boolean`` (nullable) dtype keeps ``None`` distinct from ``False`` —
+        # the nullable scalars compare ``==`` to native bools but are
+        # ``numpy.bool_`` instances, not ``True``/``False`` singletons.
+        assert df.loc["known", "resolved"] == True  # noqa: E712
+        assert df.loc["unknown_outcome", "resolved"] is pd.NA
+        assert df.loc["unknown_cost", "resolved"] == False  # noqa: E712
+        assert pd.isna(df.loc["unknown_cost", "cost"])
+        assert df.loc["known", "cost"] == 0.5
+
+    def test_empty_when_no_sidecars_present(self, tmp_path):
+        # The leaderboard config refuses to publish empty (RuntimeError);
+        # the instances config returns an empty frame with the documented
+        # schema so the workflow can still publish a leaderboard-only
+        # snapshot when sidecars haven't been generated yet.
+        _write_model(tmp_path / "results" / "GPT-X")
+
+        with patch.object(publish_hf_dataset, "REPO_ROOT", tmp_path):
+            df = publish_hf_dataset.build_instances_dataframe()
+
+        assert df.empty
+        assert list(df.columns) == publish_hf_dataset.INSTANCES_COLUMNS
+
+    def test_parquet_roundtrip_preserves_nullability(self, tmp_path):
+        # Catches regressions where ``to_parquet`` would silently downcast
+        # nullable ``boolean`` to ``object`` and lose the distinction
+        # between ``False`` and ``None``.
+        m = tmp_path / "results" / "GPT-X"
+        _write_model(m)
+        _write_sidecar(m, "swe-bench", {
+            "i1": {"resolved": None, "cost": None},
+            "i2": {"resolved": True, "cost": 1.5},
+        })
+
+        with patch.object(publish_hf_dataset, "REPO_ROOT", tmp_path):
+            df = publish_hf_dataset.build_instances_dataframe()
+
+        out = tmp_path / "instances.parquet"
+        df.to_parquet(out, index=False)
+        rt = pd.read_parquet(out)
+        rt = rt.set_index("instance_id")
+        assert rt.loc["i1", "resolved"] is pd.NA
+        assert pd.isna(rt.loc["i1", "cost"])
+        assert rt.loc["i2", "resolved"] == True  # noqa: E712
+        assert rt.loc["i2", "cost"] == 1.5
+
+
+class TestContentHash:
+    """The publish skip-check hashes *both* DataFrames so sidecar-only
+    changes (leaderboard unchanged) still trigger a publish."""
+
+    def test_hash_changes_when_only_instances_change(self):
+        leaderboard = pd.DataFrame({"id": ["a"], "score": [0.5]})
+        instances_a = pd.DataFrame({
+            "id": ["a"], "benchmark": ["swe-bench"], "instance_id": ["x"],
+            "resolved": [True], "cost": [0.1],
+        })
+        instances_b = pd.DataFrame({
+            "id": ["a"], "benchmark": ["swe-bench"], "instance_id": ["x"],
+            "resolved": [False], "cost": [0.1],
+        })
+        h_a = publish_hf_dataset.content_hash(leaderboard, instances_a)
+        h_b = publish_hf_dataset.content_hash(leaderboard, instances_b)
+        assert h_a != h_b, (
+            "content_hash must distinguish sidecar-only changes; otherwise "
+            "PR #1219-style updates would silently skip publish."
+        )
+
+    def test_hash_stable_when_inputs_unchanged(self):
+        leaderboard = pd.DataFrame({"id": ["a"], "score": [0.5]})
+        instances = pd.DataFrame({
+            "id": ["a"], "benchmark": ["swe-bench"], "instance_id": ["x"],
+            "resolved": [True], "cost": [0.1],
+        })
+        assert (
+            publish_hf_dataset.content_hash(leaderboard, instances)
+            == publish_hf_dataset.content_hash(leaderboard, instances)
+        )
+
+
+class TestDatasetCardConfigs:
+    """The card must declare both configs in the YAML frontmatter so HF
+    exposes them via ``load_dataset(..., name=...)``."""
+
+    def _card(self, instances_df=None):
+        return publish_hf_dataset.dataset_card(
+            df=pd.DataFrame({
+                "language_model": ["m"], "sdk_version": ["1"],
+                "agent_name": ["OpenHands"], "average_score": [0.5],
+                "categories_completed": [1], "release_date": ["2026-06-08"],
+            }),
+            generated_at="2026-06-18 12:00:00 UTC",
+            source_sha="abc1234deadbeef",
+            version="2026.06.18-abc1234",
+            info_version="2026.6.18",
+            instances_df=instances_df,
+        )
+
+    def test_yaml_declares_both_configs(self):
+        # Parsed as YAML so a future formatting tweak (e.g. inline lists)
+        # can't silently break the contract that consumers rely on.
+        yaml = pytest.importorskip("yaml")
+        card = self._card(instances_df=pd.DataFrame({"x": [1, 2, 3]}))
+        frontmatter = card.split("---", 2)[1]
+        meta = yaml.safe_load(frontmatter)
+
+        configs = {c["config_name"]: c for c in meta["configs"]}
+        assert set(configs) == {"default", "instances"}
+        assert configs["default"]["data_files"] == [
+            {"split": "test", "path": "test.parquet"}
+        ]
+        assert configs["instances"]["data_files"] == [
+            {"split": "test", "path": "instances.parquet"}
+        ]
+
+        # ``dataset_info`` must carry one HF-valid version per config —
+        # both share the same source commit so the versions match.
+        infos = {d["config_name"]: d for d in meta["dataset_info"]}
+        assert set(infos) == {"default", "instances"}
+        assert all(_HF_VERSION_RE.match(d["version"]) for d in infos.values())
+
+    def test_body_reports_instances_row_count(self):
+        card = self._card(instances_df=pd.DataFrame({"x": list(range(42))}))
+        body = card.split("---", 2)[2]
+        # The card surfaces both row counts so a quick eyeball of the
+        # dataset page confirms a publish actually included the sidecars.
+        assert "42" in body
+        assert "instances" in body.lower()
+
+    def test_works_without_instances_df(self):
+        # Backwards compatibility: the function still renders if a caller
+        # (e.g. an ad-hoc local invocation) omits ``instances_df``.
+        card = self._card(instances_df=None)
+        body = card.split("---", 2)[2]
+        assert "0" in body  # instances_rows defaults to 0


### PR DESCRIPTION
## Summary

Adds a second config (`instances`) to the [`OpenHands/openhands-index`](https://huggingface.co/datasets/OpenHands/openhands-index) HF dataset, built from the per-instance sidecars introduced in #1219. Consumers can now do:

```python
from datasets import load_dataset

# leaderboard — unchanged
ds = load_dataset("OpenHands/openhands-index", split="test")

# new: long-form per-instance outcomes
instances = load_dataset("OpenHands/openhands-index", "instances", split="test")
```

## Why this is needed

When #1219 merged, the `Publish HF Dataset` workflow ran but logged:

> `Dataset already up-to-date (remote hash matches). Skipping push.`

That's because `publish_hf_dataset.py` only read `metadata.json`/`scores.json`, so the leaderboard parquet was byte-identical and the new sidecars never made it to HF. This PR fixes both the missing data and the silent-skip.

## Design choices (per discussion)

- **One `instances` config, one `instances.parquet`, single `test` split**, with a `benchmark` column as the discriminator. The 5 sidecar schemas are identical (`{instance_id: {resolved, cost}}`), so splitting into 5 configs would buy nothing — `~40k` rows compress to a couple MB. If a future benchmark needs columns the others don't, that's the moment to promote it.
- **Results-only** — `_iter_instance_results_files()` mirrors the existing `_iter_model_dirs()` policy (#1145). Sidecars under `alternative_agents/` are intentionally skipped for now; broadening that is a separate product decision.
- **Schema** of `instances.parquet`:
  | Column | Type |
  |---|---|
  | `id` | string (joins to `default.id`, e.g. `OpenHands/GPT-5.5`) |
  | `agent_name` | string |
  | `agent_type` | string |
  | `language_model` | string |
  | `benchmark` | string (one of the 5) |
  | `category` | string (human-facing label) |
  | `instance_id` | string |
  | `resolved` | nullable `boolean` |
  | `cost` | nullable `float64` |

  Nullable dtypes are deliberate so `resolved=null` and `cost=null` survive the parquet round-trip without collapsing to `False` / `NaN`.

## What changed

- **`scripts/publish_hf_dataset.py`**
  - New `build_instances_dataframe()` (+ helpers) walking `results/*/instance_results/*.json`.
  - `content_hash()` now hashes **both** DataFrames, so sidecar-only updates (the exact #1219 scenario) flip the hash and trigger a publish.
  - `dataset_card()` declares both configs in the YAML frontmatter and documents the `instances` schema in the body. The existing `info_version` digits-only invariant (#1189) is preserved per config.
  - One commit, one tag (`v{version}`) still pin both parquets atomically.
- **`tests/test_publish_hf_dataset.py`**
  - 10 new tests covering: alt-agents exclusion, multi-benchmark flatten, unknown-benchmark sidecar skip, null preservation in-memory **and** across parquet round-trip, hash sensitivity to sidecar-only changes, both configs present in the rendered YAML, backwards-compat with `instances_df=None`.

## Validation

Local against the current `results/` tree:

```
leaderboard rows: 34
instances rows: 40643
instance benchmarks: ['commit0', 'gaia', 'swe-bench', 'swe-bench-multimodal', 'swt-bench']
resolved null count: 475
cost null count: 608
```

All 240 tests pass (`uv`-equivalent: `pytest tests/ -q`).

## Rollout

Once merged, the workflow's content hash will no longer match the remote, so the next run pushes both parquets in a single commit and tags it. No workflow changes required — `results/**` already matches the sidecar paths.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2161c667-19c0-4acb-8012-d1882ee0220d)