### PR TITLE
fix: stop recommended-models.json churn on unchanged content

### DIFF
--- a/scripts/generate_recommended_models.py
+++ b/scripts/generate_recommended_models.py
@@ -208,7 +208,14 @@ def pick_recommendations(
     summaries: list[ModelSummary],
     open_weights_limit: int = DEFAULT_OPEN_WEIGHTS_LIMIT,
 ) -> dict:
-    """Pick the best model per cloud family and the top open-weights models."""
+    """Pick the best model per cloud family and the top open-weights models.
+
+    The ``generated_at`` field is intentionally left unset here; it is filled in
+    by :func:`write_recommendations`, which only bumps the timestamp when the
+    substantive content (everything except ``generated_at``) actually changes.
+    This keeps automated runs from opening PRs that touch nothing but a
+    timestamp.
+    """
     closed = [
         s
         for s in summaries
@@ -230,16 +237,56 @@ def pick_recommendations(
     open_weights_data = [s.to_dict() for s in open_weights[:open_weights_limit]]
 
     return {
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00"),
         "cloud_by_family": cloud_by_family,
         "open_weights": open_weights_data,
     }
 
 
 def write_recommendations(output_path: Path, recommendations: dict) -> None:
+    """Write recommendations, preserving ``generated_at`` when content is unchanged.
+
+    On every run we compare the new recommendations (excluding ``generated_at``)
+    against the existing file's content (also excluding ``generated_at``). When
+    they match we keep the old ``generated_at`` so the file is byte-identical
+    and no churn PR is created; only real content changes advance the timestamp.
+    """
     output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    new_content = {
+        "cloud_by_family": recommendations["cloud_by_family"],
+        "open_weights": recommendations["open_weights"],
+    }
+
+    previous_generated_at: Optional[str] = None
+    content_unchanged = False
+    if output_path.exists():
+        try:
+            existing = json.loads(output_path.read_text())
+            if isinstance(existing, dict):
+                previous_generated_at = existing.get("generated_at")
+                existing_content = {
+                    "cloud_by_family": existing.get("cloud_by_family"),
+                    "open_weights": existing.get("open_weights"),
+                }
+                content_unchanged = existing_content == new_content
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"Warning: could not read existing {output_path}: {exc}")
+
+    if content_unchanged:
+        generated_at = previous_generated_at
+    else:
+        generated_at = datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S+00:00"
+        )
+
+    # Always emit keys in a stable order so the file is byte-identical across
+    # runs when the content has not changed.
+    output = {
+        "generated_at": generated_at,
+        **new_content,
+    }
     with output_path.open("w") as fh:
-        json.dump(recommendations, fh, indent=2)
+        json.dump(output, fh, indent=2)
         fh.write("\n")
 
 

--- a/tests/test_generate_recommended_models.py
+++ b/tests/test_generate_recommended_models.py
@@ -231,7 +231,9 @@ def test_pick_recommendations_returns_empty_when_no_models() -> None:
     rec = pick_recommendations([])
     assert rec["cloud_by_family"] == []
     assert rec["open_weights"] == []
-    assert "generated_at" in rec
+    # generated_at is intentionally not set by pick_recommendations; it is
+    # filled in by write_recommendations only when content changes.
+    assert "generated_at" not in rec
 
 
 # ---------------------------------------------------------------------------
@@ -240,25 +242,119 @@ def test_pick_recommendations_returns_empty_when_no_models() -> None:
 
 
 def test_write_recommendations_round_trips(tmp_path: Path) -> None:
-    payload = {
-        "generated_at": "2026-05-27T00:00:00+00:00",
-        "cloud_by_family": [
-            {
-                "model": "claude-opus-4-7",
-                "model_path": "results/claude-opus-4-7",
-                "average_score": 68.2,
-                "benchmarks_count": 5,
-                "family": "Claude",
-                "openness": "closed_api_available",
-                "model_string": "anthropic/claude-opus-4-7",
-            }
-        ],
-        "open_weights": [],
-    }
+    """A first write (no existing file) sets generated_at to now."""
+    cloud_by_family = [
+        {
+            "model": "claude-opus-4-7",
+            "model_path": "results/claude-opus-4-7",
+            "average_score": 68.2,
+            "benchmarks_count": 5,
+            "family": "Claude",
+            "openness": "closed_api_available",
+            "model_string": "anthropic/claude-opus-4-7",
+        }
+    ]
+    recommendations = {"cloud_by_family": cloud_by_family, "open_weights": []}
 
     out = tmp_path / "recommended-models.json"
-    write_recommendations(out, payload)
+    write_recommendations(out, recommendations)
 
     text = out.read_text()
     assert text.endswith("\n")
-    assert json.loads(text) == payload
+    written = json.loads(text)
+    assert written["cloud_by_family"] == cloud_by_family
+    assert written["open_weights"] == []
+    assert "generated_at" in written  # set to now on first write
+
+
+def test_write_recommendations_preserves_timestamp_when_unchanged(
+    tmp_path: Path,
+) -> None:
+    """Re-running with identical content must not bump generated_at.
+
+    This is the guard against churn PRs that touch nothing but a timestamp.
+    """
+    cloud = [
+        {
+            "model": "claude-opus-4-7",
+            "model_path": "results/claude-opus-4-7",
+            "average_score": 68.2,
+            "benchmarks_count": 5,
+            "family": "Claude",
+            "openness": "closed_api_available",
+            "model_string": "anthropic/claude-opus-4-7",
+        }
+    ]
+    out = tmp_path / "recommended-models.json"
+
+    # First write: no existing file, so generated_at is set to now.
+    write_recommendations(out, {"cloud_by_family": cloud, "open_weights": []})
+    first_text = out.read_text()
+    original_ts = json.loads(first_text)["generated_at"]
+
+    # Second write: identical content, should keep the old timestamp and be
+    # byte-identical to the first write.
+    write_recommendations(out, {"cloud_by_family": cloud, "open_weights": []})
+
+    assert json.loads(out.read_text())["generated_at"] == original_ts
+    assert out.read_text() == first_text
+
+
+def test_write_recommendations_bumps_timestamp_on_content_change(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """When the recommendation content changes, generated_at advances."""
+    from datetime import datetime as real_datetime, timezone as real_tz
+
+    import generate_recommended_models as grm
+
+    # Fake clock: first call returns t0, second call returns t1.
+    times = iter(
+        [
+            real_datetime(2026, 6, 1, 12, 0, 0, tzinfo=real_tz.utc),
+            real_datetime(2026, 6, 2, 12, 0, 0, tzinfo=real_tz.utc),
+        ]
+    )
+
+    class _FakeDateTime:
+        @staticmethod
+        def now(tz=None):
+            return next(times)
+
+        timezone = real_tz
+
+    monkeypatch.setattr(grm, "datetime", _FakeDateTime)
+
+    cloud = [
+        {
+            "model": "claude-opus-4-7",
+            "model_path": "results/claude-opus-4-7",
+            "average_score": 68.2,
+            "benchmarks_count": 5,
+            "family": "Claude",
+            "openness": "closed_api_available",
+            "model_string": "anthropic/claude-opus-4-7",
+        }
+    ]
+    out = tmp_path / "recommended-models.json"
+
+    write_recommendations(out, {"cloud_by_family": cloud, "open_weights": []})
+    original_ts = json.loads(out.read_text())["generated_at"]
+
+    # Content changes: a different model now tops the Claude family.
+    new_cloud = [
+        {
+            "model": "claude-opus-4-8",
+            "model_path": "results/claude-opus-4-8",
+            "average_score": 72.0,
+            "benchmarks_count": 5,
+            "family": "Claude",
+            "openness": "closed_api_available",
+            "model_string": "anthropic/claude-opus-4-8",
+        }
+    ]
+    write_recommendations(out, {"cloud_by_family": new_cloud, "open_weights": []})
+    written = json.loads(out.read_text())
+
+    assert written["generated_at"] != original_ts
+    assert written["cloud_by_family"][0]["model"] == "claude-opus-4-8"


### PR DESCRIPTION
## Problem

The `Update Complete Models` workflow opened PRs like #1221 that touched nothing but the `generated_at` timestamp in `recommended-models.json`. This happened because `generate_recommended_models.py` set `generated_at = datetime.now()` on every run, so the file always differed even when the recommendations were byte-for-byte identical.

## Fix

`write_recommendations` now compares the new content (excluding `generated_at`) against the existing file and preserves the old timestamp when nothing else changed. The file is byte-identical across unchanged runs, so the workflow's `git diff` finds no change and no churn PR is created.

- Real content changes still advance `generated_at` to the current time.
- Key ordering is normalized so unchanged runs produce exactly the same bytes.

## Testing

- Run twice → identical output (verified locally).
- Simulated content change → timestamp advanced, file differed (verified locally).
- Added unit tests for both preserve and bump paths.
- Full suite: 236 passed.

_This PR was created by an AI agent (OpenHands) on behalf of the user._