### PR TITLE
Mark claude-fable-5 available and recommend it

### DIFF
--- a/recommended-models.json
+++ b/recommended-models.json
@@ -1,14 +1,14 @@
 {
-  "generated_at": "2026-06-18T21:07:32+00:00",
+  "generated_at": "2026-07-01T20:11:42+00:00",
   "cloud_by_family": [
     {
-      "model": "claude-opus-4-8",
-      "model_path": "results/claude-opus-4-8",
-      "average_score": 71.9,
+      "model": "claude-fable-5",
+      "model_path": "results/claude-fable-5",
+      "average_score": 81.0,
       "benchmarks_count": 5,
       "family": "Claude",
       "openness": "closed_api_available",
-      "model_string": null
+      "model_string": "anthropic/claude-fable-5"
     },
     {
       "model": "GPT-5.5",

--- a/results/claude-fable-5/metadata.json
+++ b/results/claude-fable-5/metadata.json
@@ -12,5 +12,5 @@
   "output_price": 50.0,
   "cache_read_price": 1.0,
   "cache_write_price": 12.5,
-  "available": false
+  "available": true
 }

--- a/scripts/generate_recommended_models.py
+++ b/scripts/generate_recommended_models.py
@@ -54,6 +54,7 @@ DEFAULT_OPEN_WEIGHTS_LIMIT = 5
 # rather than computing them so the docs stay stable when a provider
 # renames an endpoint or a new alias appears.
 DEFAULT_MODEL_STRINGS: dict[str, str] = {
+    "claude-fable-5": "anthropic/claude-fable-5",
     "claude-opus-4-7": "anthropic/claude-opus-4-7",
     "claude-opus-4-6": "anthropic/claude-opus-4-6",
     "claude-opus-4-5": "anthropic/claude-opus-4-5",

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -476,7 +476,7 @@ class Metadata(BaseModel):
         """Ensure available is set correctly for known unavailable models."""
         model = info.data.get("model")
         if model is not None:
-            unavailable_models = {Model.GEMINI_3_PRO, Model.CLAUDE_FABLE_5}
+            unavailable_models = {Model.GEMINI_3_PRO}
             if model in unavailable_models and v is not False:
                 raise ValueError(
                     f"Model '{model.value}' is not available from the provider. "

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -1033,31 +1033,8 @@ class TestMetadataSchema:
         assert valid is False
         assert "not available" in msg.lower() or "false" in msg.lower()
 
-    def test_available_false_for_claude_fable_5(self, tmp_path):
-        """Test that available=False is required for claude-fable-5."""
-        metadata = {
-            "agent_name": "OpenHands",
-            "agent_version": "v1.18.1",
-            "model": "claude-fable-5",
-            "country": "us",
-            "openness": "closed_api_available",
-            "tool_usage": "standard",
-            "directory_name": "claude-fable-5",
-            "release_date": "2026-06-09",
-            "supports_vision": True,
-            "input_price": 10.0,
-            "output_price": 50.0,
-            "available": False
-        }
-        metadata_file = tmp_path / "metadata.json"
-        metadata_file.write_text(json.dumps(metadata))
-
-        valid, msg = validate_metadata(metadata_file)
-        assert valid is True
-        assert msg == "OK"
-
-    def test_available_true_for_claude_fable_5_fails(self, tmp_path):
-        """Test that available=True for claude-fable-5 is rejected."""
+    def test_available_true_for_claude_fable_5(self, tmp_path):
+        """Test that available=True is accepted for claude-fable-5."""
         metadata = {
             "agent_name": "OpenHands",
             "agent_version": "v1.18.1",
@@ -1076,8 +1053,31 @@ class TestMetadataSchema:
         metadata_file.write_text(json.dumps(metadata))
 
         valid, msg = validate_metadata(metadata_file)
+        assert valid is True
+        assert msg == "OK"
+
+    def test_available_false_for_claude_fable_5_fails(self, tmp_path):
+        """Test that available=False for claude-fable-5 is rejected."""
+        metadata = {
+            "agent_name": "OpenHands",
+            "agent_version": "v1.18.1",
+            "model": "claude-fable-5",
+            "country": "us",
+            "openness": "closed_api_available",
+            "tool_usage": "standard",
+            "directory_name": "claude-fable-5",
+            "release_date": "2026-06-09",
+            "supports_vision": True,
+            "input_price": 10.0,
+            "output_price": 50.0,
+            "available": False
+        }
+        metadata_file = tmp_path / "metadata.json"
+        metadata_file.write_text(json.dumps(metadata))
+
+        valid, msg = validate_metadata(metadata_file)
         assert valid is False
-        assert "not available" in msg.lower() or "false" in msg.lower()
+        assert "available from the provider" in msg.lower() or "true" in msg.lower()
 
     def test_available_false_for_available_model_fails(self, tmp_path):
         """Test that available=False for an available model is rejected."""


### PR DESCRIPTION
## Summary
- set results/claude-fable-5 metadata available to true
- remove claude-fable-5 from the unavailable model validator exception
- update schema tests for the new availability state
- regenerate recommended-models.json and add the claude-fable-5 model string

## Tests
- pytest tests/test_validate_schema.py tests/test_generate_recommended_models.py